### PR TITLE
[23] Integrate createch data fetching pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,13 @@ define execute_in_env
 	source bin/conda_activate.sh && conda_activate && $1
 endef
 
+.PHONY: fetch-daps1
+## Fetch GtR and crunchbase data from DAPS1
+fetch-daps1:
+	MYSQL_CONFIG=$(MYSQL_CONFIG) python innovation_sweet_spots/pipeline/fetch_daps1_data/flow.py --no-pylint\
+	 --environment=conda\
+	 run
+
 .PHONY: init
 ## Fully initialise a project: install; setup github repo; setup S3 bucket
 init: install setup-github setup-bucket

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
   - Setup the conda environment
   - Configure pre-commit
   - Configure metaflow to use AWS
+- Run `conda config --add channels conda-forge`
 
 ### Data access
 
@@ -18,12 +19,9 @@ To download input data from Nesta database, you will first need to decrypt the c
 $ git stash
 $ git-crypt unlock /path/to/key
 ```
+The GtR and CB data can be fetched by running `make fetch-daps1`
 
-The most recent version of the input data can then be fetched by running
-
-```shell
-python innovation_sweet_spots/getters/inputs.py
-```
+For downloading Hansard data, consult documentation in `innovation_sweet_spots/getters/inputs.py`
 
 ## Contributor guidelines
 

--- a/innovation_sweet_spots/getters/crunchbase.py
+++ b/innovation_sweet_spots/getters/crunchbase.py
@@ -1,3 +1,7 @@
+"""
+Module for easy access to downloaded GTR data
+
+"""
 import pandas as pd
 import sys
 from innovation_sweet_spots.getters.inputs import CB_PATH

--- a/innovation_sweet_spots/getters/crunchbase.py
+++ b/innovation_sweet_spots/getters/crunchbase.py
@@ -1,0 +1,23 @@
+import pandas as pd
+import sys
+from innovation_sweet_spots.getters.inputs import CB_PATH
+
+
+def get_crunchbase_orgs():
+    return pd.read_csv(f"{CB_PATH}/crunchbase_organisations.csv")
+
+
+def get_crunchbase_orgs_full():
+    return pd.read_csv(f"{CB_PATH}/crunchbase_organizations.csv")
+
+
+def get_crunchbase_category_groups():
+    return pd.read_csv(f"{CB_PATH}/crunchbase_category_groups.csv")
+
+
+def get_crunchbase_organizations_categories():
+    return pd.read_csv(f"{CB_PATH}/crunchbase_organizations_categories.csv")
+
+
+def get_crunchbase_funding_rounds():
+    return pd.read_csv(f"{CB_PATH}/crunchbase_funding_rounds.csv")

--- a/innovation_sweet_spots/getters/gtr.py
+++ b/innovation_sweet_spots/getters/gtr.py
@@ -1,0 +1,19 @@
+# Fetch GtR tables
+import pandas as pd
+from innovation_sweet_spots.getters.inputs import GTR_PATH
+
+
+def get_gtr_projects():
+    return pd.read_csv(f"{GTR_PATH}/gtr_projects.csv")
+
+
+def get_link_table():
+    return pd.read_csv(f"{GTR_PATH}/gtr_link_table.csv")
+
+
+def get_gtr_funds():
+    return pd.read_csv(f"{GTR_PATH}/gtr_funds.csv")
+
+
+def get_gtr_topics():
+    return pd.read_csv(f"{GTR_PATH}/gtr_topics.csv")

--- a/innovation_sweet_spots/getters/gtr.py
+++ b/innovation_sweet_spots/getters/gtr.py
@@ -1,4 +1,7 @@
-# Fetch GtR tables
+"""
+Module for easy access to downloaded GTR data
+
+"""
 import pandas as pd
 from innovation_sweet_spots.getters.inputs import GTR_PATH
 

--- a/innovation_sweet_spots/getters/inputs.py
+++ b/innovation_sweet_spots/getters/inputs.py
@@ -162,10 +162,10 @@ def unzip_files(path_to_zip_archive, extract_path, delete=False):
 
 if __name__ == "__main__":
     """Downloads all input files"""
-    INPUTS_PATH.mkdir(parents=True, exist_ok=True)
-    get_gtr_projects(use_cached=False)
+    GTR_PATH.mkdir(parents=True, exist_ok=True)
+    get_gtr_projects()
     CB_PATH.mkdir(parents=True, exist_ok=True)
-    get_cb_data(use_cached=False)
+    get_cb_data()
     HANSARD_PATH.mkdir(parents=True, exist_ok=True)
     download_hansard_data()
     # Add other getter functions here

--- a/innovation_sweet_spots/getters/inputs.py
+++ b/innovation_sweet_spots/getters/inputs.py
@@ -16,7 +16,7 @@ import zipfile
 import urllib
 
 INPUTS_PATH = PROJECT_DIR / "inputs/data/"
-GTR_PATH = INPUTS_PATH / "gtr_projects.csv"
+GTR_PATH = INPUTS_PATH / "gtr"
 CB_PATH = INPUTS_PATH / "cb"
 CB_DATA_SPEC_PATH = PROJECT_DIR / "innovation_sweet_spots/config/cb_data_spec.yaml"
 HANSARD_PATH = INPUTS_PATH / "hansard"
@@ -25,7 +25,9 @@ ZENODO_FILES = ["hansard-speeches-v310.csv.zip", "parliamentary_posts.json"]
 ZENODO_URLS = map(ZENODO_BASE.format, ZENODO_FILES)
 
 
-def get_gtr_projects(fpath=GTR_PATH, fields=["id"], use_cached=True):
+def get_gtr_projects(
+    fpath=GTR_PATH / "gtr_projects.json", fields=["id"], use_cached=True
+):
     """
     Downloads GTR projects from Nesta database and stores them locally.
     Function can be used from command line as follows:

--- a/innovation_sweet_spots/pipeline/fetch_daps1_data/cb_utils.py
+++ b/innovation_sweet_spots/pipeline/fetch_daps1_data/cb_utils.py
@@ -1,0 +1,64 @@
+import logging
+from pathlib import Path
+from typing import Dict
+
+import pandas as pd
+
+from daps1_utils import fetch_daps_table, save_daps_table
+
+CB_PATH = Path(__file__).parents[3] / "inputs/data/cb"
+logger = logging.getLogger(__name__)
+
+
+def filter_uk(table: pd.DataFrame, ids: set, var_name: str = "org_id"):
+    """Gets UK companies from crunchbase
+    Args:
+        table: crunchbase table
+        ids: UK company ids
+        var_name: name of org id variable
+    Returns:
+        filtered table
+    """
+    return table.loc[table[var_name].isin(ids)].reset_index(drop=True)
+
+
+def fetch_save_crunchbase():
+    """Fetch and save crunchbase data"""
+    cb_orgs = pd.concat(fetch_daps_table("crunchbase_organizations", fields="all"))
+
+    cb_uk = cb_orgs.loc[cb_orgs["country"] == "United Kingdom"].drop_duplicates(
+        subset=["id"]
+    )
+    logging.info(len(cb_uk))
+    save_daps_table(cb_uk, "crunchbase_organisations", CB_PATH)
+
+    cb_uk_ids = set(cb_uk["id"])
+
+    cb_funding_rounds = pd.concat(
+        fetch_daps_table("crunchbase_funding_rounds", fields="all")
+    )
+    cb_funding_rounds_uk = filter_uk(cb_funding_rounds, cb_uk_ids)
+
+    cb_orgs_cats = pd.concat(
+        fetch_daps_table("crunchbase_organizations_categories", fields="all")
+    )
+    cb_org_cats_uk = filter_uk(cb_orgs_cats, cb_uk_ids, "organization_id")
+
+    category_group = pd.concat(
+        fetch_daps_table("crunchbase_category_groups", fields="all")
+    )
+
+    save_daps_table(cb_funding_rounds_uk, "crunchbase_funding_rounds", CB_PATH)
+    save_daps_table(cb_org_cats_uk, "crunchbase_organizations_categories", CB_PATH)
+    save_daps_table(category_group, "crunchbase_category_groups", CB_PATH)
+
+
+def get_uk_names(con) -> Dict[str, str]:
+    """Fetch non-null `{id: name}` pairs from `crunchbase_organizations` in the UK."""
+
+    query = """
+    SELECT id, name
+    FROM crunchbase_organizations
+    WHERE country = 'United Kingdom'
+    """
+    return pd.read_sql_query(query, con).set_index("id").name.dropna().to_dict()

--- a/innovation_sweet_spots/pipeline/fetch_daps1_data/daps1_utils.py
+++ b/innovation_sweet_spots/pipeline/fetch_daps1_data/daps1_utils.py
@@ -1,0 +1,88 @@
+# Generic scripts to get DAPS tables
+import logging
+import os
+from configparser import ConfigParser
+from typing import Any, Dict, Iterator
+
+import pandas as pd
+from sqlalchemy import create_engine
+from sqlalchemy.engine.url import URL
+
+# from pandas._typing import FilePathOrBuffer  # Not available in pandas < 1
+
+MYSQL_CONFIG = os.environ["MYSQL_CONFIG"]
+
+
+def get_engine(config_path, database="production", **engine_kwargs):
+    """Get a SQL alchemy engine from config"""
+    cp = ConfigParser()
+    cp.read(config_path)
+    cp = cp["client"]
+    url = URL(
+        drivername="mysql+pymysql",
+        database=database,
+        username=cp["user"],
+        host=cp["host"],
+        password=cp["password"],
+    )
+    return create_engine(url, **engine_kwargs)
+
+
+def fetch_daps_table(table_name: str, fields: str = "all") -> pd.DataFrame:
+    """Fetch DAPS tables if we don't have them already
+    Args:
+        table_name: name
+        path: path for the table
+        fields: fields to fetch. If a list, fetches those
+    Returns:
+        table
+    """
+    logging.info(f"Fetching {table_name}")
+    engine = get_engine(MYSQL_CONFIG)
+    con = engine.connect().execution_options(stream_results=True)
+
+    if fields == "all":
+        chunks = pd.read_sql_table(table_name, con, chunksize=1000)
+    else:
+        chunks = pd.read_sql_table(table_name, con, columns=fields, chunksize=1000)
+
+    return chunks
+
+
+def stream_df_to_csv(
+    df_iterator: Iterator[pd.DataFrame],
+    path_or_buf: Any,  # FilePathOrBuffer
+    **kwargs,
+):
+    """Stream a DataFrame iterator to csv.
+
+    Args:
+        df_iterator: DataFrame chunks to stream to CSV
+        path_or_buf: FilePath or Buffer (passed to `DataFrame.to_csv`)
+        kwargs: Extra args passed to `DataFrame.to_csv`. Cannot contain
+            any of `{"mode", "header", "path_or_buf"}` - `mode` is "a" and
+            `header` is `False` for all but initial chunks.
+
+
+    Raises:
+        ValueError if `kwargs` contains disallowed values.
+    """
+    if any((key in kwargs for key in ["mode", "header", "path_or_buf"])):
+        raise ValueError()
+
+    # First chunk: mode "w" and write column names
+    initial = next(df_iterator)
+    initial.to_csv(path_or_buf, **kwargs)
+    # Subsequent chunks:
+    for chunk in df_iterator:
+        chunk.to_csv(path_or_buf, mode="a", header=False, **kwargs)
+
+
+def save_daps_table(table: pd.DataFrame, name: str, path: str):
+    """Save DAPS tables
+    Args:
+        table: table to save
+        name: table name
+        path: directory where we store the table
+    """
+    table.to_csv(f"{path}/{name}.csv", index=False)

--- a/innovation_sweet_spots/pipeline/fetch_daps1_data/flow.py
+++ b/innovation_sweet_spots/pipeline/fetch_daps1_data/flow.py
@@ -1,0 +1,75 @@
+"""Metaflow to fetch data from DAPS1 (`nestauk/nesta`).
+
+GtR and Crunchbase data pipeline currently reside `nestauk/nesta`.
+fetched using the `nestauk/data_getters` internal library.
+"""
+import os
+
+from metaflow import conda_base, FlowSpec, Parameter, step
+
+ENV_VAR = "MYSQL_CONFIG"
+
+LIBRARIES = {"pymysql": "0.9.3", "sqlalchemy": "1.3.4", "pandas": ">1"}
+
+
+@conda_base(python="3.7", libraries=LIBRARIES)
+class CreatechNestaGetter(FlowSpec):
+
+    db_config_path = Parameter("db-config-path", type=str, default=os.environ[ENV_VAR])
+
+    @step
+    def start(self):
+        self.next(self.fetch_names)
+
+    @step
+    def fetch_names(self):
+        """Fetch Organisation (GtR & crunchbase) names."""
+        from daps1_utils import get_engine
+        from gtr_utils import get_names as get_gtr_names
+        from cb_utils import get_uk_names as get_cb_names
+
+        if self.db_config_path is None:
+            raise ValueError(
+                f"`db_config_path` was not set. Pass in a config path as a "
+                f"flow argument or set {ENV_VAR} env variable."
+            )
+
+        engine = get_engine(self.db_config_path)
+        con = engine.connect()
+
+        self.gtr_names = get_gtr_names(con)
+        self.crunchbase_names = get_cb_names(con)
+
+        self.next(self.fetch_cb)
+
+    @step
+    def fetch_cb(self):
+        """Fetch Crunchbase tables."""
+        from cb_utils import CB_PATH, fetch_save_crunchbase
+
+        if os.path.exists(CB_PATH) is False:
+            os.makedirs(CB_PATH)
+
+        fetch_save_crunchbase()
+
+        self.next(self.fetch_gtr)
+
+    @step
+    def fetch_gtr(self):
+        """Fetch GtR tables."""
+        from gtr_utils import GTR_PATH, fetch_save_gtr_tables
+
+        if os.path.exists(GTR_PATH) is False:
+            os.mkdir(GTR_PATH)
+
+        fetch_save_gtr_tables()
+
+        self.next(self.end)
+
+    @step
+    def end(self):
+        pass
+
+
+if __name__ == "__main__":
+    CreatechNestaGetter()

--- a/innovation_sweet_spots/pipeline/fetch_daps1_data/gtr_utils.py
+++ b/innovation_sweet_spots/pipeline/fetch_daps1_data/gtr_utils.py
@@ -1,0 +1,80 @@
+# Fetch GtR tables
+# TODO: Add organisations and funding tables
+import logging
+from pathlib import Path
+from typing import Dict, Iterator
+
+import pandas as pd
+
+from daps1_utils import (
+    get_engine,
+    fetch_daps_table,
+    MYSQL_CONFIG,
+    stream_df_to_csv,
+)
+
+logger = logging.getLogger(__name__)
+GTR_PATH = Path(__file__).parents[3] / "inputs/data/gtr"
+
+
+def projects_funded_from_2006() -> Iterator[pd.DataFrame]:
+    """GtR projects with funding starting from 2006.
+
+    Returns:
+        Iterable of query results
+    """
+    engine = get_engine(MYSQL_CONFIG)
+    con = engine.connect().execution_options(stream_results=True)
+    query = """
+    SELECT
+        DISTINCT gtr_projects.id AS project_id,
+        gtr_projects.title,
+        gtr_projects.grantCategory,
+        gtr_projects.leadFunder,
+        gtr_projects.abstractText,
+        gtr_projects.potentialImpact,
+        gtr_projects.techAbstractText,
+        gtr_funds.start
+    FROM
+        gtr_projects
+            INNER JOIN
+                (SELECT * FROM gtr_link_table
+                 WHERE gtr_link_table.table_name = 'gtr_funds')
+                AS l
+                ON l.project_id = gtr_projects.id
+            INNER JOIN
+                (SELECT * FROM gtr_funds
+                 WHERE YEAR(gtr_funds.start) > 2006)
+                AS gtr_funds
+                ON l.id = gtr_funds.id
+    GROUP BY gtr_projects.id HAVING MIN(YEAR(gtr_funds.start));
+    """
+
+    return pd.read_sql_query(query, con, chunksize=1000)
+
+
+def fetch_save_gtr_tables():
+
+    funders = fetch_daps_table("gtr_funds")
+    stream_df_to_csv(funders, path_or_buf=f"{GTR_PATH}/gtr_funds.csv", index=False)
+
+    topics = fetch_daps_table("gtr_topic")
+    stream_df_to_csv(topics, f"{GTR_PATH}/gtr_topics.csv", index=False)
+
+    link = fetch_daps_table("gtr_link_table")
+    stream_df_to_csv(link, f"{GTR_PATH}/gtr_link_table.csv", index=False)
+
+    logging.info("Filtering projects...")
+    projects_filtered = projects_funded_from_2006()
+    stream_df_to_csv(projects_filtered, f"{GTR_PATH}/gtr_projects.csv", index=False)
+
+
+def get_names(con) -> Dict[str, str]:
+    """Fetch non-null `{id: name}` pairs from gtr_organisations."""
+
+    return (
+        pd.read_sql_table("gtr_organisations", con, columns=["id", "name"])
+        .set_index("id")
+        .name.dropna()
+        .to_dict()
+    )


### PR DESCRIPTION
Closes #23

Integration of a pipeline from the Createch project's codebase, for fetching Crunchbase and GTR data from `daps_1`. This is a much more sophisticated approach than what I was trying with #12 and #14. Most of the new code is copy-pasted from the Createch codebase, so it should probably be fine!

The pipeline can be ran by the command `make fetch-daps1`

Some outstanding questions:
- Not sure if tests are necessary for this? (didn't find tests in the Createch repo)
- I guess can still keep the functions & tests written up in #12 and #14, and see if they're useful later on. However, this pipeline in principle removes the dependency on `data_getters`(which is a good thing ?)

---

Checklist:

- [x] I have refactored my code out from `notebooks/`
- [x] I have checked the code runs
- [ ] I have tested the code
- [x] I have run `pre-commit` and addressed any issues not automatically fixed
- [x] I have merged any new changes from `dev`
- [x] I have documented the code
  - [x] Major functions have docstrings
  - [x] Appropriate information has been added to `README`s
- [x] I have explained the feature in this PR or (better) in `output/reports/`
- [x] I have requested a code review
