### PR TITLE
[58] Added organisations and locations to `GtrWrangler`

### DIFF
--- a/innovation_sweet_spots/analysis/README.md
+++ b/innovation_sweet_spots/analysis/README.md
@@ -31,3 +31,5 @@ Add data on organisations that participate in the projects and the organisation 
 
 GtR.get_organisations_and_locations(gtr_projects)
 ```
+
+Add people data and something else...

--- a/innovation_sweet_spots/analysis/README.md
+++ b/innovation_sweet_spots/analysis/README.md
@@ -1,0 +1,33 @@
+# Analysis modules
+
+See examples below on using the analysis modules (going forward, this should be transformed into a proper documentation)
+
+## Data wrangling
+
+Module `wrangling_utils` helps fetching and linking data related to research projects and businesses.
+
+### Research projects
+
+```python
+from innovation_sweet_spots.getters import gtr
+from innovation_sweet_spots.analysis.wrangling_utils import GtrWrangler
+
+# Prepare a small sample of projects
+gtr_projects = gtr.get_gtr_projects().head(3)
+
+# Initiate a data wrangler instance
+GtR = GtrWrangler()
+```
+
+Adding data on funding amounts and the start and end dates of funding (the first run might take longer as it needs to load in funding data)
+
+```python
+GtR.get_funding_data(gtr_projects)
+```
+
+Add data on organisations that participate in the projects and the organisation locations
+
+```python
+
+GtR.get_organisations_and_locations(gtr_projects)
+```

--- a/innovation_sweet_spots/analysis/README.md
+++ b/innovation_sweet_spots/analysis/README.md
@@ -28,8 +28,11 @@ GtR.get_funding_data(gtr_projects)
 Add data on organisations that participate in the projects and the organisation locations
 
 ```python
-
 GtR.get_organisations_and_locations(gtr_projects)
 ```
 
-Add people data and something else...
+Adding information about the people participating in the projects
+
+```python
+GtR.get_persons(gtr_projects)
+```

--- a/innovation_sweet_spots/analysis/examples/04_getting_gtr_participants.py
+++ b/innovation_sweet_spots/analysis/examples/04_getting_gtr_participants.py
@@ -42,8 +42,7 @@ gtr_projects = gtr.get_gtr_projects().head(3)
 GtR.get_organisations_and_locations(gtr_projects)
 
 # %% [markdown]
-# ### Finding participants
-#
-# Coming soon...
+# ## Finding participants
 
 # %%
+GtR.get_persons(gtr_projects)

--- a/innovation_sweet_spots/analysis/examples/04_getting_gtr_participants.py
+++ b/innovation_sweet_spots/analysis/examples/04_getting_gtr_participants.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+# ---
+# jupyter:
+#   jupytext:
+#     cell_metadata_filter: -all
+#     comment_magics: true
+#     formats: ipynb,py:percent
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.11.3
+#   kernelspec:
+#     display_name: Python 3
+#     language: python
+#     name: python3
+# ---
+
+# %% [markdown]
+# # Getting GTR research project participant data
+#
+# Organisations and people
+
+# %%
+from innovation_sweet_spots.getters import gtr
+from innovation_sweet_spots.analysis.wrangling_utils import GtrWrangler
+import pandas as pd
+from innovation_sweet_spots import PROJECT_DIR
+
+# Initiate an instance of GtrWrangler and get the data
+GtR = GtrWrangler()
+
+# %% [markdown]
+# ## Fetching organisation data
+#
+
+# %%
+# Import projects table
+gtr_projects = gtr.get_gtr_projects().head(3)
+
+# %%
+GtR.get_organisations_and_locations(gtr_projects)
+
+# %% [markdown]
+# ### Finding participants
+#
+# Coming soon...
+
+# %%

--- a/innovation_sweet_spots/analysis/wrangling_utils.py
+++ b/innovation_sweet_spots/analysis/wrangling_utils.py
@@ -24,6 +24,9 @@ class GtrWrangler:
         self._gtr_organisations = None
         self._gtr_organisations_locations = None
         self._link_gtr_organisations = None
+        # People
+        self._gtr_persons = None
+        self._link_gtr_persons = None
 
     def get_project_funds(self, gtr_projects: pd.DataFrame) -> pd.DataFrame:
         """
@@ -176,6 +179,31 @@ class GtrWrangler:
             self.get_organisation_locations,
         )
 
+    def get_persons(self, gtr_projects: pd.DataFrame) -> pd.DataFrame:
+        """
+        Adds participating persons to the projects.
+
+        Args:
+            gtr_projects: Data frame that must have a column "project_id"
+
+        Returns:
+            Same input data frame with the following extra columns:
+                - id: Person id
+                - person_relation: Indicates different types of participation
+                - firstName
+                - otherNames
+                - surname
+
+        """
+        return (
+            # Add person ids to the projects table
+            gtr_projects.merge(self.link_gtr_persons, on="project_id", how="left")
+            # Add person data
+            .merge(self.gtr_persons, on="id", how="left")
+            .drop(["table_name"], axis=1)
+            .rename(columns={"rel": "person_relation"})
+        )
+
     @property
     def gtr_funds(self):
         """GtR funding table"""
@@ -217,6 +245,20 @@ class GtrWrangler:
         if self._link_gtr_organisations is None:
             self._link_gtr_organisations = gtr.get_link_table("gtr_organisations")
         return self._link_gtr_organisations
+
+    @property
+    def gtr_persons(self):
+        """Links between project ids and organisation ids"""
+        if self._gtr_persons is None:
+            self._gtr_persons = gtr.get_gtr_persons()
+        return self._gtr_persons
+
+    @property
+    def link_gtr_persons(self):
+        """Links between project ids and organisation ids"""
+        if self._link_gtr_persons is None:
+            self._link_gtr_persons = gtr.get_link_table("gtr_persons")
+        return self._link_gtr_persons
 
 
 class CrunchbaseWrangler:

--- a/innovation_sweet_spots/getters/gtr.py
+++ b/innovation_sweet_spots/getters/gtr.py
@@ -35,7 +35,12 @@ def get_gtr_topics() -> pd.DataFrame:
 
 def get_gtr_organisations() -> pd.DataFrame:
     """GtR research organisations"""
-    return pd.read_csv(GTR_PATH / "gtr_organizations.csv")
+    return pd.read_csv(GTR_PATH / "gtr_organisations.csv")
+
+
+def get_gtr_organisations_locations() -> pd.DataFrame:
+    """GtR research organisations"""
+    return pd.read_csv(GTR_PATH / "gtr_organisations_locations.csv")
 
 
 def get_link_table(table: str = None) -> pd.DataFrame:

--- a/innovation_sweet_spots/getters/gtr.py
+++ b/innovation_sweet_spots/getters/gtr.py
@@ -39,8 +39,13 @@ def get_gtr_organisations() -> pd.DataFrame:
 
 
 def get_gtr_organisations_locations() -> pd.DataFrame:
-    """GtR research organisations"""
+    """GtR research organisation locations"""
     return pd.read_csv(GTR_PATH / "gtr_organisations_locations.csv")
+
+
+def get_gtr_persons() -> pd.DataFrame:
+    """GtR research participants"""
+    return pd.read_csv(GTR_PATH / "gtr_persons.csv")
 
 
 def get_link_table(table: str = None) -> pd.DataFrame:


### PR DESCRIPTION
Closes #58 

Adds data on organisations that participate in UKRI-funded research projects and the organisation locations (address, country, latitude and longitude)

Usage:

```python
from innovation_sweet_spots.getters import gtr
from innovation_sweet_spots.analysis.wrangling_utils import GtrWrangler

# Prepare a small sample of projects
gtr_projects = gtr.get_gtr_projects().head(3)
# Initiate a data wrangler instance
GtR = GtrWrangler()

GtR.get_organisations_and_locations(gtr_projects)
```

You can also run the notebook `04_getting_gtr_participants.py` to test the usage.

---

Checklist:

- [x] I have refactored my code out from `notebooks/`
- [x] I have checked the code runs
- [x] I have tested the code
- [x] I have run `pre-commit` and addressed any issues not automatically fixed
- [x] I have merged any new changes from `dev`
- [x] I have documented the code
  - [x] Major functions have docstrings
  - [x] Appropriate information has been added to `README`s
- [x] I have explained the feature in this PR or (better) in `output/reports/`
- [x] I have requested a code review
