### PR TITLE
[81] Added research topics to GtR

### DIFF
--- a/innovation_sweet_spots/analysis/wrangling_utils.py
+++ b/innovation_sweet_spots/analysis/wrangling_utils.py
@@ -19,6 +19,9 @@ class GtrWrangler:
         self._link_gtr_funds_api = None
         self._project_to_funds = None
         self._gtr_funds = None
+        # Research topics
+        self._link_gtr_topics = None
+        self._gtr_topics = None
 
     def get_project_funds(self, gtr_projects: pd.DataFrame) -> pd.DataFrame:
         """
@@ -105,6 +108,26 @@ class GtrWrangler:
         """Adds reliable funding amount data, and funding start and end dates to the projects."""
         return pipe(gtr_projects, self.get_project_funds_api, self.get_start_end_dates)
 
+    def get_research_topics(self, gtr_projects: pd.DataFrame) -> pd.DataFrame:
+        """
+         Add research topics to projects. Note that about half of the projects are 'Unclassified'
+
+         Args:
+             gtr_projects: Data frame that must have a column "project_id"
+
+         Returns:
+             Same input data frame with the following extra columns:
+                 - topic: 750+ different project categories
+                 - topic_type: One of the following: 'researchActivity', 'researchTopic', 'researchSubject',
+        'healthCategory', 'rcukProgramme'
+        """
+        return (
+            gtr_projects.merge(self.link_gtr_topics, on="project_id", how="left")
+            .merge(self.gtr_topics, on="id", how="left")
+            .drop(["rel", "table_name", "id"], axis=1)
+            .rename(columns={"text": "topic"})
+        )
+
     @property
     def gtr_funds(self):
         """GtR funding table"""
@@ -125,6 +148,20 @@ class GtrWrangler:
         if self._link_gtr_funds_api is None:
             self._link_gtr_funds_api = gtr.get_gtr_funds_api()
         return self._link_gtr_funds_api
+
+    @property
+    def link_gtr_topics(self):
+        """Links between project ids and research topic ids"""
+        if self._link_gtr_funds is None:
+            self._link_gtr_funds = gtr.get_link_table("gtr_topic")
+        return self._link_gtr_funds
+
+    @property
+    def gtr_topics(self):
+        """GtR research topics"""
+        if self._gtr_topics is None:
+            self._gtr_topics = gtr.get_gtr_topics()
+        return self._gtr_topics
 
 
 class CrunchbaseWrangler:
@@ -269,7 +306,7 @@ class CrunchbaseWrangler:
             # If nothing to convert, copy the nulls and return
             df[converted_column] = df[amount_column].copy()
         return df
-      
+
     def get_funding_round_investors(self, funding_rounds: pd.DataFrame) -> pd.DataFrame:
         """
         Gets the investors involved in the specified funding rounds


### PR DESCRIPTION
Closes #81 

Added functionality to fetch GtR project research topics.

Usage example:
```python
from innovation_sweet_spots.getters import gtr
from innovation_sweet_spots.analysis.wrangling_utils import GtrWrangler

# Prepare a small sample of projects
gtr_projects = gtr.get_gtr_projects().head(3)
# Initiate a data wrangler instance
GtR = GtrWrangler()

GtR.get_research_topics(gtr_projects)
```
---

Checklist:

- [x] I have refactored my code out from `notebooks/`
- [x] I have checked the code runs
- [ ] I have tested the code
- [x] I have run `pre-commit` and addressed any issues not automatically fixed
- [x] I have merged any new changes from `dev`
- [x] I have documented the code
  - [x] Major functions have docstrings
  - [x] Appropriate information has been added to `README`s
- [x] I have explained the feature in this PR or (better) in `output/reports/`
- [x] I have requested a code review
