### PR TITLE
[76] Add Crunchbase person data

### DIFF
--- a/innovation_sweet_spots/analysis/examples/03_getting_cb_data.py
+++ b/innovation_sweet_spots/analysis/examples/03_getting_cb_data.py
@@ -115,14 +115,6 @@ filtered_companies[["name", "country"]]
 # ## Find persons working in specific companies
 
 # %%
-import importlib
-from innovation_sweet_spots.getters import crunchbase as cb
-import innovation_sweet_spots.analysis.wrangling_utils as wu
-
-importlib.reload(wu)
-CB = wu.CrunchbaseWrangler()
-
-# %%
 # Get a sample of Crunchbase organisations
 cb_orgs = cb.get_crunchbase_orgs(100)
 

--- a/innovation_sweet_spots/analysis/examples/03_getting_cb_data.py
+++ b/innovation_sweet_spots/analysis/examples/03_getting_cb_data.py
@@ -26,7 +26,7 @@
 # Prerequisite: Fetching CB data by running `make fetch-daps1` from the main repo directory
 
 # %%
-from innovation_sweet_spots.getters import crunchbase
+from innovation_sweet_spots.getters import crunchbase as cb
 import altair as alt
 import itertools
 
@@ -111,4 +111,36 @@ filtered_companies = CB.select_companies_by_industries(companies, filtering_indu
 # %%
 filtered_companies[["name", "country"]]
 
+# %% [markdown]
+# ## Find persons working in specific companies
+
 # %%
+import importlib
+from innovation_sweet_spots.getters import crunchbase as cb
+import innovation_sweet_spots.analysis.wrangling_utils as wu
+
+importlib.reload(wu)
+CB = wu.CrunchbaseWrangler()
+
+# %%
+# Get a sample of Crunchbase organisations
+cb_orgs = cb.get_crunchbase_orgs(100)
+
+# Find people associate with these organisations
+cb_org_persons = CB.get_company_persons(cb_orgs)
+
+# %%
+cb_org_persons[["name", "person_name", "linkedin_url"]]
+
+# %% [markdown]
+# ### Fetching person university degrees
+
+# %%
+CB.get_person_degrees(cb_org_persons).head(3)
+
+# %% [markdown]
+# ### Fetching company education data
+
+# %%
+df = CB.get_company_education_data(cb_orgs)
+df

--- a/innovation_sweet_spots/getters/crunchbase.py
+++ b/innovation_sweet_spots/getters/crunchbase.py
@@ -41,3 +41,13 @@ def get_crunchbase_investments() -> pd.DataFrame:
 def get_crunchbase_investors() -> pd.DataFrame:
     """Table with investors"""
     return pd.read_csv(CB_PATH / "crunchbase_investors.csv")
+
+
+def get_crunchbase_people() -> pd.DataFrame:
+    """Table with people"""
+    return pd.read_csv(CB_PATH / "crunchbase_people.csv")
+
+
+def get_crunchbase_degrees() -> pd.DataFrame:
+    """Table with university degrees"""
+    return pd.read_csv(CB_PATH / "crunchbase_degrees.csv")


### PR DESCRIPTION
Closes #76 

Added functions to `CrunchbaseWrangler` to fetch data about company employees and their education

Usage:
```python
from innovation_sweet_spots.analysis.wrangling_utils import CrunchbaseWrangler
from innovation_sweet_spots.getters import crunchbase as cb

CB = CrunchbaseWrangler()

# Get a sample of Crunchbase organisations
cb_orgs = cb.get_crunchbase_orgs(100)

# Find people associated with these organisations
cb_org_persons = CB.get_company_persons(cb_orgs)

# Fetch person university degrees
CB.get_person_degrees(cb_org_persons)

# Get education data for the specified companies
CB.get_company_education_data(cb_orgs)
```

---

Checklist:

- [x] I have refactored my code out from `notebooks/`
- [x] I have checked the code runs
- [ ] I have tested the code
- [x] I have run `pre-commit` and addressed any issues not automatically fixed
- [x] I have merged any new changes from `dev`
- [x] I have documented the code
  - [x] Major functions have docstrings
  - [x] Appropriate information has been added to `README`s
- [x] I have explained the feature in this PR or (better) in `output/reports/`
- [ ] I have requested a code review
