### PR TITLE
[99] Create time series grouped monthly/quarterly

### DIFF
--- a/innovation_sweet_spots/analysis/analysis_utils.py
+++ b/innovation_sweet_spots/analysis/analysis_utils.py
@@ -2,6 +2,7 @@
 Utils for doing data analysis
 """
 import pandas as pd
+import numpy as np
 from innovation_sweet_spots.analysis.wrangling_utils import check_valid
 
 
@@ -25,7 +26,8 @@ def impute_empty_periods(
     Returns:
         A dataframe with imputed 0s for time periods with no data
     """
-    max_year = max(df_time_period[time_period_col].max().year, max_year)
+    max_year_data = np.nan_to_num(df_time_period[time_period_col].max().year)
+    max_year = max(max_year_data, max_year)
     full_period_range = (
         pd.period_range(
             f"01/01/{min_year}",

--- a/innovation_sweet_spots/analysis/analysis_utils.py
+++ b/innovation_sweet_spots/analysis/analysis_utils.py
@@ -78,7 +78,7 @@ def gtr_deduplicate_projects(gtr_docs: pd.DataFrame) -> pd.DataFrame:
 
 def gtr_funding_per_period(gtr_docs: pd.DataFrame, period: str) -> pd.DataFrame:
     """
-    Given a table with projects and their funding, return an aggregation by year
+    Given a table with projects and their funding, return an aggregation by period
 
     Args:
         gtr_docs: A dataframe with columns for 'start', 'project_id' and 'amount'
@@ -88,9 +88,9 @@ def gtr_funding_per_period(gtr_docs: pd.DataFrame, period: str) -> pd.DataFrame:
     Returns:
         A dataframe with the following columns:
             'period' - time period
-            'no_of_projects' - number of new projects in a given year,
-            'amount_total' - total amount of research funding in a given year,
-            'amount_median' - median project funding in a given year
+            'no_of_projects' - number of new projects in a given period,
+            'amount_total' - total amount of research funding in a given period,
+            'amount_median' - median project funding in a given period
 
     """
     # Convert project start dates to time period

--- a/innovation_sweet_spots/analysis/analysis_utils.py
+++ b/innovation_sweet_spots/analysis/analysis_utils.py
@@ -96,7 +96,6 @@ def gtr_funding_per_period(gtr_docs: pd.DataFrame, period: str) -> pd.DataFrame:
     # Convert project start dates to time period
     gtr_docs = (
         gtr_docs.copy()
-        .astype({"start": "datetime64[ns]"})
         .assign(time_period=lambda x: x.start.dt.strftime("%Y-%m-%d"))
         .astype({"time_period": "datetime64[ns]"})
     )

--- a/innovation_sweet_spots/analysis/analysis_utils.py
+++ b/innovation_sweet_spots/analysis/analysis_utils.py
@@ -1,45 +1,41 @@
 """
 Utils for doing data analysis
-
 """
 import pandas as pd
-import numpy as np
-from typing import Tuple
 from innovation_sweet_spots.analysis.wrangling_utils import check_valid
 
 
-def impute_empty_years(
-    yearly_stats: pd.DataFrame, min_year: int = None, max_year: int = None
+def impute_empty_periods(
+    df_time_period: pd.DataFrame,
+    time_period_col: str,
+    period: str,
+    min_year: int,
+    max_year: int,
 ) -> pd.DataFrame:
     """
-    Imputes zero values for years without data
+    Imputes zero values for time periods without data
 
     Args:
-        yearly_stats: A dataframe with a 'year' column and other columns with data
-        min_year: Lower bound for years to keep; can be smaller than yearly_stats.year.min()
-        max_year: Higher bound for years; can be larger than yearly_stats.year.min()
+        df_time_period: A dataframe with a column containing time period data
+        time_period_col: Column containing time period data
+        period: Time period that the data is grouped by, 'M', 'Q' or 'Y'
+        min_year: Earliest year to impute values for
+        max_year: Last year to impute values for
 
     Returns:
-        A data frame with imputed 0s for years with no data
+        A dataframe with imputed 0s for time periods with no data
     """
-    min_year, max_year = set_def_min_max_years(yearly_stats, min_year, max_year)
-    return (
-        pd.DataFrame(data={"year": range(min_year, max_year + 1)})
-        .merge(yearly_stats, how="left")
-        .fillna(0)
-        .astype(yearly_stats.dtypes)
+    full_period_range = (
+        pd.period_range(
+            f"01/01/{min_year}",
+            f"31/12/{max_year}",
+            freq=period,
+        )
+        .to_timestamp()
+        .to_frame(index=False, name=time_period_col)
+        .reset_index(drop=True)
     )
-
-
-def set_def_min_max_years(
-    df: pd.DataFrame, min_year: int, max_year: int
-) -> Tuple[int, int]:
-    """Set the default values for min and max years"""
-    if min_year is None:
-        min_year = df.year.min()
-    if max_year is None:
-        max_year = df.year.max()
-    return min_year, max_year
+    return full_period_range.merge(df_time_period, "left").fillna(0)
 
 
 ### GtR specific utils
@@ -154,39 +150,41 @@ def gtr_get_all_timeseries_period(
 ### Crunchbase specific utils
 
 
-def cb_orgs_founded_per_year(
-    cb_orgs: pd.DataFrame, min_year: int = None, max_year: int = None
+def cb_orgs_founded_per_period(
+    cb_orgs: pd.DataFrame, period: str, min_year: int, max_year: int
 ) -> pd.DataFrame:
     """
-    Calculates the number of Crunchbase organisations founded in a given year
+    Calculates the number of Crunchbase organisations founded per period
 
     Args:
         cb_orgs: A dataframe with columns for 'id' and 'founded_on' among other data
-        min_year: Lower bound for years to keep
-        max_year: Higher bound for years to keep
+        period: Time period the data is grouped by, 'M', 'Q' or 'Y'
+        min_year: Earliest year to impute values for
+        max_year: Last year to impute values for
 
     Returns:
         A dataframe with the following columns:
-            'year',
-            'no_of_orgs_founded' - number of new organisations founded in a given year
+            'time_period',
+            'no_of_orgs_founded' - number of new organisations founded in a given time period
     """
     # Remove orgs that don't have year when they were founded
-    cb_orgs = cb_orgs[-cb_orgs.founded_on.isnull()].copy()
-    # Convert dates to years
-    cb_orgs["year"] = pd.to_datetime(cb_orgs.founded_on).dt.year
-    # Set min and max years for aggregation
-    min_year, max_year = set_def_min_max_years(cb_orgs, min_year, max_year)
-    # Group by year
-    return (
-        cb_orgs.groupby("year")
-        .agg(no_of_orgs_founded=("id", "count"))
-        .reset_index()
-        .pipe(impute_empty_years, min_year=min_year, max_year=max_year)
+    cb_orgs = (
+        cb_orgs[-cb_orgs.founded_on.isnull()]
+        .copy()
+        .assign(time_period=lambda x: pd.to_datetime(x.founded_on))
+    )
+    # Group by time period
+    grouped = cb_orgs.groupby(cb_orgs["time_period"].dt.to_period(period)).agg(
+        no_of_orgs_founded=("id", "count")
+    )
+    grouped.index = grouped.index.astype("datetime64[ns]")
+    return impute_empty_periods(
+        grouped.reset_index(), "time_period", period, min_year, max_year
     )
 
 
-def cb_investments_per_year(
-    cb_funding_rounds: pd.DataFrame, min_year: int = None, max_year: int = None
+def cb_investments_per_period(
+    cb_funding_rounds: pd.DataFrame, period: str, min_year: int, max_year: int
 ) -> pd.DataFrame:
     """
     Aggregates the raised investment amount and number of deals across all orgs
@@ -194,65 +192,70 @@ def cb_investments_per_year(
     Args:
         cb_funding_rounds: A dataframe with columns for 'funding_round_id', 'raised_amount_usd'
             'raised_amount_gbp' and 'announced_on' among other data
-        min_year: Lower bound for years to keep
-        max_year: Higher bound for years to keep
+        period: Time period the data is grouped by, 'M', 'Q' or 'Y'
+        min_year: Earliest year to impute values for
+        max_year: Last year to impute values for
 
     Returns:
         A dataframe with the following columns:
-            'year',
+            'time_period',
             'no_of_rounds' - number of funding rounds (deals) in a given year
             'raised_amount_usd_total' - total raised investment (USD) in a given year
             'raised_amount_gbp_total' - total raised investment (GBP) in a given year
     """
-    # Convert dates to years
-    cb_funding_rounds["year"] = pd.to_datetime(cb_funding_rounds.announced_on).dt.year
-    # Set min and max years for aggregation
-    min_year, max_year = set_def_min_max_years(cb_funding_rounds, min_year, max_year)
-    # Group by year
-    return (
-        cb_funding_rounds.groupby("year")
-        .agg(
-            no_of_rounds=("funding_round_id", "count"),
-            raised_amount_usd_total=("raised_amount_usd", "sum"),
-            raised_amount_gbp_total=("raised_amount_gbp", "sum"),
-        )
-        .reset_index()
-        .query(f"year>={min_year}")
-        .query(f"year<={max_year}")
-        .pipe(impute_empty_years, min_year=min_year, max_year=max_year)
+    # Create time period column
+    cb_funding_rounds["time_period"] = pd.to_datetime(cb_funding_rounds.announced_on)
+    # Group by time period
+    grouped = cb_funding_rounds.groupby(
+        cb_funding_rounds["time_period"].dt.to_period(period)
+    ).agg(
+        no_of_rounds=("funding_round_id", "count"),
+        raised_amount_usd_total=("raised_amount_usd", "sum"),
+        raised_amount_gbp_total=("raised_amount_gbp", "sum"),
+    )
+    grouped.index = grouped.index.astype("datetime64[ns]")
+    return impute_empty_periods(
+        grouped.reset_index(), "time_period", period, min_year, max_year
     )
 
 
 def cb_get_all_timeseries(
     cb_orgs: pd.DataFrame,
     cb_funding_rounds: pd.DataFrame,
-    min_year: int = None,
-    max_year: int = None,
+    period: str,
+    min_year: int,
+    max_year: int,
 ) -> pd.DataFrame:
     """
-    Calculates all typical time series from a list of GtR projects and return
-    as one combined table
+    Combines crunchbase organisations and deals data to produce time series data
+    for funding rounds, orgs foundded and amount raised
 
     Args:
         cb_orgs: A dataframe with columns for 'id' and 'founded_on' among other data
         cb_funding_rounds: A dataframe with columns for 'funding_round_id', 'raised_amount_usd'
             'raised_amount_gbp' and 'announced_on' among other data
-        min_year: Lower bound for years to keep
-        max_year: Higher bound for years to keep
+        period: Time period to group the data by, 'month', 'quarter' or 'year'
+        min_year: Earliest year to impute values for
+        max_year: Last year to impute values for
 
     Returns:
         A dataframe with the following columns:
-            'year',
+            'time_period',
             'no_of_rounds' - number of funding rounds (deals) in a given year
             'raised_amount_usd_total' - total raised investment (USD) in a given year
             'raised_amount_gbp_total' - total raised investment (GBP) in a given year
             'no_of_orgs_founded' - number of new organisations founded in a given year
     """
+    # Check and reformat period
+    check_valid(period, ["year", "month", "quarter"])
+    period = period[0].capitalize()
     # Number of new companies per year
-    time_series_orgs_founded = cb_orgs_founded_per_year(cb_orgs, min_year, max_year)
+    time_series_orgs_founded = cb_orgs_founded_per_period(
+        cb_orgs, period, min_year, max_year
+    )
     # Amount of raised investment per year
-    time_series_investment = cb_investments_per_year(
-        cb_funding_rounds, min_year, max_year
+    time_series_investment = cb_investments_per_period(
+        cb_funding_rounds, period, min_year, max_year
     )
     # Join up both tables
     time_series_investment["no_of_orgs_founded"] = time_series_orgs_founded[

--- a/innovation_sweet_spots/analysis/wrangling_utils.py
+++ b/innovation_sweet_spots/analysis/wrangling_utils.py
@@ -128,7 +128,7 @@ class GtrWrangler:
         return pipe(gtr_projects, self.get_project_funds_api, self.get_start_end_dates)
 
     def split_funding_data(
-        self, gtr_projects: pd.DataFrame, time_period: str
+        self, gtr_projects: pd.DataFrame, time_period: str = "month"
     ) -> pd.DataFrame:
         """
         Splits GtR funding evenly over the duration of the projects
@@ -137,18 +137,14 @@ class GtrWrangler:
             gtr_projects: Dataframe that must have columns for 'fund_start'
                 and 'fund_end'
             time_period: Time period to split the funding data across,
-                must be one of 'year', 'month', 'quarter'
+                must be one of 'year', 'month', 'quarter'. Defaults to 'month'.
 
         Returns:
             Same input dataframe but with additional rows for
             the time periods that the funding has been split across
         """
         # Check time period is valid
-        valid_time_periods = ["year", "month", "quarter"]
-        if time_period not in valid_time_periods:
-            raise ValueError(
-                f"gtr_funding_evenly_split: time_period must be one of {valid_time_periods}."
-            )
+        check_valid(time_period, ["year", "month", "quarter"])
 
         # Add split info
         frequency = time_period[0].capitalize()
@@ -956,3 +952,9 @@ def split_comma_seperated_string(text: str) -> Iterator[str]:
 def is_string_in_list(list_of_strings: Iterator[str], list_to_check: Iterator[str]):
     """Checks if any of the provided strings in list_of_strings are in the specified list_to_check"""
     return True in [s in list_to_check for s in list_of_strings]
+
+
+def check_valid(check_var, check_list):
+    """Raise ValueError is check_var not in check_list"""
+    if check_var not in check_list:
+        raise ValueError(f"{check_var} is not valid, it must be one of {check_list}.")

--- a/innovation_sweet_spots/pipeline/pilot/README.md
+++ b/innovation_sweet_spots/pipeline/pilot/README.md
@@ -1,0 +1,17 @@
+## Producing time series data
+
+To produce time series run the scripts in this directory from the terminal.
+
+`timeseries_cb.py` needs an argument relating to what time period (either month, quarter or year) to group the data by.
+For example, to produce the crunchbase time series with the data grouped montly, run this from terminal:
+
+```
+ python timeseries_cb.py month
+```
+
+`timeseries_gtr.py` needs an argument relating to what time period (either month, quarter or year) to group the data by. It also has an optional flag (`--split`) whether to split the research funding more evenly across the duration of research projects.
+For example, to produce the GtR data grouped yearly and have the research funding split, run this from terminal:
+
+```
+ python timeseries_gtr.py year --split
+```

--- a/innovation_sweet_spots/pipeline/pilot/timeseries_cb.py
+++ b/innovation_sweet_spots/pipeline/pilot/timeseries_cb.py
@@ -1,6 +1,7 @@
 """
 Script to generate time series from Crunchbase data
 """
+import typer
 from innovation_sweet_spots import PROJECT_DIR, logging
 from innovation_sweet_spots.utils.io import import_config
 import innovation_sweet_spots.analysis.analysis_utils as au
@@ -12,14 +13,18 @@ ORGS_TABLE = "ISS_pilot_Crunchbase_companies.csv"
 DEALS_TABLE = "ISS_pilot_Crunchbase_deals.csv"
 # Parameters (tech categories to process, time series limits)
 PARAMS = import_config("iss_pilot.yaml")
-PERIOD = "year"
 # Output files
-EXPORT_DIR = DATA_DIR / "time_series/cb" / PERIOD
 OUTFILE_NAME = "Time_series_Crunchbase_{}_{}.csv"
 
-if __name__ == "__main__":
 
-    EXPORT_DIR.mkdir(parents=True, exist_ok=True)
+def cb_timeseries(period: str):
+    """Loads, processes and saves Crunchbase time series data
+
+    Args:
+        period: Period to group the data by, 'month', 'quarter' or 'year'
+    """
+    export_dir = DATA_DIR / "time_series/cb" / period
+    export_dir.mkdir(parents=True, exist_ok=True)
 
     # Load data
     cb_orgs = au.filter_years(
@@ -50,7 +55,7 @@ if __name__ == "__main__":
         time_series_investment = au.cb_get_all_timeseries(
             category_cb_orgs,
             category_deals,
-            period=PERIOD,
+            period=period,
             min_year=PARAMS["min_year"],
             max_year=PARAMS["max_year"],
         )
@@ -58,12 +63,16 @@ if __name__ == "__main__":
 
         # Export
         time_series_investment.to_csv(
-            EXPORT_DIR / OUTFILE_NAME.format(category, PERIOD), index=False
+            export_dir / OUTFILE_NAME.format(category, period), index=False
         )
 
     logging.info(
-        f"Using {[ORGS_TABLE, DEALS_TABLE]} as input, exported {len(categories)} time series in {EXPORT_DIR}"
+        f"Using {[ORGS_TABLE, DEALS_TABLE]} as input, exported {len(categories)} time series in {export_dir}"
     )
     logging.info(
         f"The time series correspond to the following technology categories: {categories}"
     )
+
+
+if __name__ == "__main__":
+    typer.run(cb_timeseries)

--- a/innovation_sweet_spots/pipeline/pilot/timeseries_cb.py
+++ b/innovation_sweet_spots/pipeline/pilot/timeseries_cb.py
@@ -21,8 +21,21 @@ if __name__ == "__main__":
     EXPORT_DIR.mkdir(parents=True, exist_ok=True)
 
     # Load data
-    cb_orgs = pd.read_csv(DATA_DIR / ORGS_TABLE)
-    cb_deals = pd.read_csv(DATA_DIR / DEALS_TABLE)
+    cb_orgs = au.filter_years(
+        df=pd.read_csv(DATA_DIR / ORGS_TABLE),
+        date_col="founded_on",
+        keep_year_col=False,
+        min_year=PARAMS["min_year"],
+        max_year=PARAMS["max_year"],
+    )
+
+    cb_deals = au.filter_years(
+        df=pd.read_csv(DATA_DIR / DEALS_TABLE),
+        date_col="announced_on_date",
+        keep_year_col=False,
+        min_year=PARAMS["min_year"],
+        max_year=PARAMS["max_year"],
+    )
 
     # Technology categories to process
     categories = PARAMS["technology_categories"]

--- a/innovation_sweet_spots/pipeline/pilot/timeseries_cb.py
+++ b/innovation_sweet_spots/pipeline/pilot/timeseries_cb.py
@@ -12,9 +12,9 @@ ORGS_TABLE = "ISS_pilot_Crunchbase_companies.csv"
 DEALS_TABLE = "ISS_pilot_Crunchbase_deals.csv"
 # Parameters (tech categories to process, time series limits)
 PARAMS = import_config("iss_pilot.yaml")
-PERIOD = "quarter"
+PERIOD = "year"
 # Output files
-EXPORT_DIR = DATA_DIR / "time_series" / PERIOD
+EXPORT_DIR = DATA_DIR / "time_series/cb" / PERIOD
 OUTFILE_NAME = "Time_series_Crunchbase_{}_{}.csv"
 
 if __name__ == "__main__":
@@ -54,6 +54,7 @@ if __name__ == "__main__":
             min_year=PARAMS["min_year"],
             max_year=PARAMS["max_year"],
         )
+        time_series_investment["tech_category"] = category
 
         # Export
         time_series_investment.to_csv(

--- a/innovation_sweet_spots/pipeline/pilot/timeseries_cb.py
+++ b/innovation_sweet_spots/pipeline/pilot/timeseries_cb.py
@@ -10,11 +10,12 @@ import pandas as pd
 DATA_DIR = PROJECT_DIR / "outputs/finals/pilot_outputs/"
 ORGS_TABLE = "ISS_pilot_Crunchbase_companies.csv"
 DEALS_TABLE = "ISS_pilot_Crunchbase_deals.csv"
-# Output files
-EXPORT_DIR = DATA_DIR / "time_series/"
-OUTFILE_NAME = "Time_series_Crunchbase_{}.csv"
 # Parameters (tech categories to process, time series limits)
 PARAMS = import_config("iss_pilot.yaml")
+PERIOD = "quarter"
+# Output files
+EXPORT_DIR = DATA_DIR / "time_series" / PERIOD
+OUTFILE_NAME = "Time_series_Crunchbase_{}_{}.csv"
 
 if __name__ == "__main__":
 
@@ -49,13 +50,14 @@ if __name__ == "__main__":
         time_series_investment = au.cb_get_all_timeseries(
             category_cb_orgs,
             category_deals,
+            period=PERIOD,
             min_year=PARAMS["min_year"],
             max_year=PARAMS["max_year"],
         )
 
         # Export
         time_series_investment.to_csv(
-            EXPORT_DIR / OUTFILE_NAME.format(category), index=False
+            EXPORT_DIR / OUTFILE_NAME.format(category, PERIOD), index=False
         )
 
     logging.info(

--- a/innovation_sweet_spots/pipeline/pilot/timeseries_gtr.py
+++ b/innovation_sweet_spots/pipeline/pilot/timeseries_gtr.py
@@ -1,6 +1,7 @@
 """
 Script to generate time series from GtR data
 """
+import typer
 from innovation_sweet_spots import PROJECT_DIR, logging
 from innovation_sweet_spots.utils.io import import_config
 import innovation_sweet_spots.analysis.analysis_utils as au
@@ -10,18 +11,26 @@ import pandas as pd
 
 # Parameters (tech categories to process, time series limits)
 PARAMS = import_config("iss_pilot.yaml")
-SPLIT = False
-PERIOD = "month"
-
-# Output files
-EXPORT_DIR = (
-    PROJECT_DIR / "outputs/finals/pilot_outputs/time_series/gtr_split" / PERIOD
-    if SPLIT
-    else PROJECT_DIR / "outputs/finals/pilot_outputs/time_series/gtr_not_split" / PERIOD
-)
 
 
-if __name__ == "__main__":
+def gtr_timeseries(period: str, split: bool = False):
+    """Loads, processes and saves Gateway to Research time
+    series data
+
+    Args:
+        period: Period to group the data by, 'month', 'quarter' or 'year'
+        split: If True, will evenly split research funding over the duration
+            of the project. If False, will attribute research funding to the
+            start of the project.
+    """
+    # Output files
+    EXPORT_DIR = (
+        PROJECT_DIR / "outputs/finals/pilot_outputs/time_series/gtr_split" / period
+        if split
+        else PROJECT_DIR
+        / "outputs/finals/pilot_outputs/time_series/gtr_not_split"
+        / period
+    )
     # Load data
     gtr_docs = au.filter_years(
         df=get_pilot_GtR_projects(),
@@ -34,38 +43,76 @@ if __name__ == "__main__":
     # Technology categories to process
     categories = PARAMS["technology_categories"]
 
-    if SPLIT:
+    if split:
         gtr_wrangler = wu.GtrWrangler()
 
-    for category in categories:
-        # Select rows relevant to the category
-        category_gtr_docs = gtr_docs.query(f'tech_category=="{category}"').copy()
+    with typer.progressbar(categories) as progress:
+        for category in progress:
+            # Select rows relevant to the category
+            category_gtr_docs = gtr_docs.query(f'tech_category=="{category}"').copy()
 
-        if SPLIT:
-            funding_data = gtr_wrangler.get_funding_data(category_gtr_docs)
-            funding_data_split = gtr_wrangler.split_funding_data(funding_data)
-            time_series_funding = au.gtr_get_all_timeseries_period(
-                funding_data_split, PERIOD, PARAMS["min_year"], PARAMS["max_year"]
-            )
-        else:
-            time_series_funding = au.gtr_get_all_timeseries_period(
-                category_gtr_docs, PERIOD, PARAMS["min_year"], PARAMS["max_year"]
-            )
-        time_series_funding["tech_category"] = category
-        # Make dir
-        EXPORT_DIR.mkdir(parents=True, exist_ok=True)
+            if split:
+                funding_data = gtr_wrangler.get_funding_data(category_gtr_docs)
 
-        # Export
-        outfile_name = (
-            f"Time_series_GtR_split_{category}_split_{PERIOD}.csv"
-            if SPLIT
-            else f"Time_series_GtR_{category}_{PERIOD}.csv"
+                # Split monthly to group at higher level later to more accurately split funding
+                funding_data_split_monthly = gtr_wrangler.split_funding_data(
+                    funding_data, "month"
+                )
+                time_series_funding = au.gtr_get_all_timeseries_period(
+                    funding_data_split_monthly,
+                    period,
+                    PARAMS["min_year"],
+                    PARAMS["max_year"],
+                )
+
+                # Split by period (necessary for calculating median)
+                funding_data_split_period = gtr_wrangler.split_funding_data(
+                    funding_data, period
+                )
+                time_series_median = au.gtr_funding_median_per_period(
+                    funding_data_split_period,
+                    period,
+                    PARAMS["min_year"],
+                    PARAMS["max_year"],
+                )
+
+            else:
+                time_series_funding = au.gtr_get_all_timeseries_period(
+                    category_gtr_docs, period, PARAMS["min_year"], PARAMS["max_year"]
+                )
+                time_series_median = au.gtr_funding_median_per_period(
+                    category_gtr_docs,
+                    period,
+                    PARAMS["min_year"],
+                    PARAMS["max_year"],
+                )
+
+            time_series_funding_median = pd.merge(
+                time_series_funding,
+                time_series_median,
+                how="outer",
+                on="time_period",
+            )
+
+            time_series_funding_median["tech_category"] = category
+            # Make dir
+            EXPORT_DIR.mkdir(parents=True, exist_ok=True)
+
+            # Export
+            outfile_name = (
+                f"Time_series_GtR_split_{category}_split_{period}.csv"
+                if split
+                else f"Time_series_GtR_{category}_{period}.csv"
+            )
+            time_series_funding_median.to_csv(EXPORT_DIR / outfile_name, index=False)
+
+        logging.info(
+            f"Generated and exported {len(categories)} time series in {EXPORT_DIR}"
         )
-        time_series_funding.to_csv(EXPORT_DIR / outfile_name, index=False)
+        logging.info(
+            f"The time series correspond to the following technology categories: {categories}"
+        )
 
-    logging.info(
-        f"Generated and exported {len(categories)} time series in {EXPORT_DIR}"
-    )
-    logging.info(
-        f"The time series correspond to the following technology categories: {categories}"
-    )
+
+if __name__ == "__main__":
+    typer.run(gtr_timeseries)

--- a/innovation_sweet_spots/pipeline/pilot/timeseries_gtr.py
+++ b/innovation_sweet_spots/pipeline/pilot/timeseries_gtr.py
@@ -10,17 +10,18 @@ import pandas as pd
 
 # Parameters (tech categories to process, time series limits)
 PARAMS = import_config("iss_pilot.yaml")
-SPLIT = True
-SPLIT_PERIOD = "year"
+SPLIT = False
+PERIOD = "month"
 
 # Output files
-EXPORT_DIR = PROJECT_DIR / "outputs/finals/pilot_outputs/time_series/"
+EXPORT_DIR = (
+    PROJECT_DIR / "outputs/finals/pilot_outputs/time_series/gtr_split" / PERIOD
+    if SPLIT
+    else PROJECT_DIR / "outputs/finals/pilot_outputs/time_series/gtr_not_split" / PERIOD
+)
 
 
 if __name__ == "__main__":
-
-    EXPORT_DIR.mkdir(parents=True, exist_ok=True)
-
     # Load data
     gtr_docs = au.filter_years(
         df=get_pilot_GtR_projects(),
@@ -44,19 +45,21 @@ if __name__ == "__main__":
             funding_data = gtr_wrangler.get_funding_data(category_gtr_docs)
             funding_data_split = gtr_wrangler.split_funding_data(funding_data)
             time_series_funding = au.gtr_get_all_timeseries_period(
-                funding_data_split, SPLIT_PERIOD
+                funding_data_split, PERIOD, PARAMS["min_year"], PARAMS["max_year"]
             )
-            time_series_funding["tech_category"] = category
         else:
             time_series_funding = au.gtr_get_all_timeseries_period(
-                category_gtr_docs, "year"
+                category_gtr_docs, PERIOD, PARAMS["min_year"], PARAMS["max_year"]
             )
+        time_series_funding["tech_category"] = category
+        # Make dir
+        EXPORT_DIR.mkdir(parents=True, exist_ok=True)
 
         # Export
         outfile_name = (
-            f"Time_series_GtR_split_{category}_split_{SPLIT_PERIOD}.csv"
+            f"Time_series_GtR_split_{category}_split_{PERIOD}.csv"
             if SPLIT
-            else f"Time_series_GtR_{category}.csv"
+            else f"Time_series_GtR_{category}_{PERIOD}.csv"
         )
         time_series_funding.to_csv(EXPORT_DIR / outfile_name, index=False)
 

--- a/innovation_sweet_spots/tests/test_analysis_utils.py
+++ b/innovation_sweet_spots/tests/test_analysis_utils.py
@@ -4,29 +4,48 @@ import pandas as pd
 from pandas._testing import assert_frame_equal, assert_series_equal
 
 
-def test_impute_empty_years():
-    mock_input_data = {"year": [2000, 2002], "values": [1, 1]}
-    mock_df = pd.DataFrame(mock_input_data)
+def test_impute_empty_periods():
+    mock_df = pd.DataFrame(
+        {
+            "time_period": ["2000-01-01", "2002-01-01"],
+            "values": [1.0, 1.0],
+        }
+    ).astype({"time_period": "datetime64[ns]"})
 
-    df = impute_empty_years(mock_df)
-    imputed_data = {"year": [2000, 2001, 2002], "values": [1, 0, 1]}
-    assert_frame_equal(df, pd.DataFrame(imputed_data))
+    df = impute_empty_periods(mock_df, "time_period", "Y", 2000, 2002)
+    imputed_data = pd.DataFrame(
+        {
+            "time_period": ["2000-01-01", "2001-01-01", "2002-01-01"],
+            "values": [1.0, 0.0, 1.0],
+        }
+    ).astype({"time_period": "datetime64[ns]"})
+    assert df.equals(imputed_data)
 
-    df = impute_empty_years(mock_df, min_year=1999)
-    imputed_data = {"year": [1999, 2000, 2001, 2002], "values": [0, 1, 0, 1]}
-    assert_frame_equal(df, pd.DataFrame(imputed_data))
+    df = impute_empty_periods(mock_df, "time_period", "Y", 1999, 2002)
+    imputed_data = pd.DataFrame(
+        {
+            "time_period": ["1999-01-01", "2000-01-01", "2001-01-01", "2002-01-01"],
+            "values": [0.0, 1.0, 0.0, 1.0],
+        }
+    ).astype({"time_period": "datetime64[ns]"})
+    assert df.equals(imputed_data)
 
-    df = impute_empty_years(mock_df, min_year=1999, max_year=2004)
-    imputed_data = {"year": list(range(1999, 2005)), "values": [0, 1, 0, 1, 0, 0]}
-    assert_frame_equal(df, pd.DataFrame(imputed_data))
-
-
-def test_set_def_min_max_years():
-    mock_input_data = {"year": [2000, 2001, 2002], "values": [1, 1, 1]}
-    mock_df = pd.DataFrame(mock_input_data)
-    assert set_def_min_max_years(mock_df, min_year=None, max_year=None) == (2000, 2002)
-    assert set_def_min_max_years(mock_df, min_year=2001, max_year=None) == (2001, 2002)
-    assert set_def_min_max_years(mock_df, min_year=2001, max_year=2001) == (2001, 2001)
+    df = impute_empty_periods(mock_df, "time_period", "Y", 1999, 2005)
+    imputed_data = pd.DataFrame(
+        {
+            "time_period": [
+                "1999-01-01",
+                "2000-01-01",
+                "2001-01-01",
+                "2002-01-01",
+                "2003-01-01",
+                "2004-01-01",
+                "2005-01-01",
+            ],
+            "values": [0.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0],
+        }
+    ).astype({"time_period": "datetime64[ns]"})
+    assert_frame_equal(df, imputed_data)
 
 
 def test_gtr_deduplicate_projects():
@@ -47,146 +66,116 @@ def test_gtr_deduplicate_projects():
     assert_frame_equal(df, pd.DataFrame(deduplicated_data))
 
 
-def test_gtr_funding_per_year():
+def test_gtr_funding_per_period():
     mock_input_data = {
         "start": ["2001-02-01", "2002-10-01", "2002-12-05", "2004-04-01"],
         "project_id": ["a", "b", "c", "d"],
         "amount": [1000, 2000, 10000, 5000],
     }
     mock_df = pd.DataFrame(mock_input_data)
-    aggregated_df = gtr_funding_per_year(mock_df)
-    aggregated_data = {
-        "year": [2001, 2002, 2003, 2004],
-        "no_of_projects": [1, 2, 0, 1],
-        "amount_total": [1.0, 12.0, 0.0, 5.0],
-        "amount_median": [1.0, 6.0, 0.0, 5.0],
-    }
-    assert_frame_equal(aggregated_df, pd.DataFrame(aggregated_data))
-    # Set lower bound for years
-    aggregated_df = gtr_funding_per_year(mock_df, min_year=2002)
-    aggregated_data = {
-        "year": [2002, 2003, 2004],
-        "no_of_projects": [2, 0, 1],
-        "amount_total": [12.0, 0.0, 5.0],
-        "amount_median": [6.0, 0.0, 5.0],
-    }
-    assert_frame_equal(aggregated_df, pd.DataFrame(aggregated_data))
-    # Set lower and higher bound for years
-    aggregated_df = gtr_funding_per_year(mock_df, min_year=2002, max_year=2003)
-    aggregated_data = {
-        "year": [2002, 2003],
-        "no_of_projects": [2, 0],
-        "amount_total": [12.0, 0.0],
-        "amount_median": [6.0, 0.0],
-    }
-    assert_frame_equal(aggregated_df, pd.DataFrame(aggregated_data))
+    aggregated_df = gtr_funding_per_period(
+        mock_df, period="Y", min_year=2001, max_year=2004
+    )
+    aggregated_data = pd.DataFrame(
+        {
+            "time_period": ["2001-01-01", "2002-01-01", "2003-01-01", "2004-01-01"],
+            "no_of_projects": [1.0, 2.0, 0.0, 1.0],
+            "amount_total": [1.0, 12.0, 0.0, 5.0],
+        }
+    ).astype({"time_period": "datetime64[ns]"})
+    assert_frame_equal(aggregated_df, aggregated_data)
 
 
-def test_gtr_get_all_timeseries():
-    mock_input_data = {
-        "project_id": ["1", "2", "3", "4"],
-        "title": ["Project A", "Project A", "Project B", "Project C"],
-        "description": ["aaa", "aaa", "bbb", "ccc"],
-        "start": ["2001-02-01", "2002-10-01", "2002-12-05", "2004-04-01"],
-        "amount": [1000, 2000, 10000, 5000],
-    }
-    mock_df = pd.DataFrame(mock_input_data)
-    output = gtr_get_all_timeseries(mock_df)
-    output_data = {
-        "year": [2001, 2002, 2003, 2004],
-        "no_of_projects": [1, 1, 0, 1],
-        "amount_total": [1.0, 12.0, 0.0, 5.0],
-        "amount_median": [1.0, 6.0, 0.0, 5.0],
-    }
-    assert_frame_equal(output, pd.DataFrame(output_data))
+def test_gtr_get_all_timeseries_period():
+    mock_df = pd.DataFrame(
+        {
+            "project_id": ["1", "2", "3", "4"],
+            "title": ["Project A", "Project A", "Project B", "Project C"],
+            "description": ["aaa", "aaa", "bbb", "ccc"],
+            "start": ["2001-02-01", "2002-10-01", "2002-12-05", "2004-04-01"],
+            "amount": [1000, 2000, 10000, 5000],
+        }
+    )
+    output = gtr_get_all_timeseries_period(
+        mock_df, period="year", min_year=2001, max_year=2004
+    )
+    output_data = pd.DataFrame(
+        {
+            "time_period": ["2001-01-01", "2002-01-01", "2003-01-01", "2004-01-01"],
+            "no_of_projects": [1.0, 1.0, 0.0, 1.0],
+            "amount_total": [1.0, 12.0, 0.0, 5.0],
+        }
+    ).astype({"time_period": "datetime64[ns]"})
+    assert_frame_equal(output, output_data)
 
 
-def test_cb_orgs_founded_per_year():
+def test_cb_orgs_founded_per_period():
     mock_input_data = {
         "id": ["a", "b", "c", "d"],
         "founded_on": ["2001-02-01", "2002-10-01", "2002-12-05", "2004-04-01"],
     }
     mock_df = pd.DataFrame(mock_input_data)
-    aggregated_df = cb_orgs_founded_per_year(mock_df)
-    aggregated_data = {
-        "year": [2001, 2002, 2003, 2004],
-        "no_of_orgs_founded": [1, 2, 0, 1],
-    }
-    assert_frame_equal(aggregated_df, pd.DataFrame(aggregated_data))
-    # Set lower bound for years
-    aggregated_df = cb_orgs_founded_per_year(mock_df, min_year=2002)
-    aggregated_data = {
-        "year": [2002, 2003, 2004],
-        "no_of_orgs_founded": [2, 0, 1],
-    }
-    assert_frame_equal(aggregated_df, pd.DataFrame(aggregated_data))
-    # Set lower and higher bound for years
-    aggregated_df = cb_orgs_founded_per_year(mock_df, min_year=2002, max_year=2005)
-    aggregated_data = {
-        "year": [2002, 2003, 2004, 2005],
-        "no_of_orgs_founded": [2, 0, 1, 0],
-    }
-    assert_frame_equal(aggregated_df, pd.DataFrame(aggregated_data))
+    aggregated_df = cb_orgs_founded_per_period(
+        mock_df, period="Y", min_year=2001, max_year=2004
+    )
+    aggregated_data = pd.DataFrame(
+        {
+            "time_period": ["2001-01-01", "2002-01-01", "2003-01-01", "2004-01-01"],
+            "no_of_orgs_founded": [1.0, 2.0, 0.0, 1.0],
+        }
+    ).astype({"time_period": "datetime64[ns]"})
+    assert_frame_equal(aggregated_df, aggregated_data)
 
 
-def test_cb_investments_per_year():
-    mock_input_data = {
-        "funding_round_id": ["a", "b", "c", "d"],
-        "announced_on": ["2001-02-01", "2002-10-01", "2002-12-05", "2004-04-01"],
-        "raised_amount_usd": [10, 20, 30, 50],
-        "raised_amount_gbp": [12, 24, 36, 58],
-    }
-    mock_df = pd.DataFrame(mock_input_data)
-    aggregated_df = cb_investments_per_year(mock_df)
-    aggregated_data = {
-        "year": [2001, 2002, 2003, 2004],
-        "no_of_rounds": [1, 2, 0, 1],
-        "raised_amount_usd_total": [10, 50, 0, 50],
-        "raised_amount_gbp_total": [12, 60, 0, 58],
-    }
-    assert_frame_equal(aggregated_df, pd.DataFrame(aggregated_data))
-    # Set lower bound for years
-    aggregated_df = cb_investments_per_year(mock_df, min_year=2002)
-    aggregated_data = {
-        "year": [2002, 2003, 2004],
-        "no_of_rounds": [2, 0, 1],
-        "raised_amount_usd_total": [50, 0, 50],
-        "raised_amount_gbp_total": [60, 0, 58],
-    }
-    assert_frame_equal(aggregated_df, pd.DataFrame(aggregated_data))
-    # Set lower and higher bound for years
-    aggregated_df = cb_investments_per_year(mock_df, min_year=2002, max_year=2005)
-    aggregated_data = {
-        "year": [2002, 2003, 2004, 2005],
-        "no_of_rounds": [2, 0, 1, 0],
-        "raised_amount_usd_total": [50, 0, 50, 0],
-        "raised_amount_gbp_total": [60, 0, 58, 0],
-    }
-    assert_frame_equal(aggregated_df, pd.DataFrame(aggregated_data))
+def test_cb_investments_per_period():
+    mock_df = pd.DataFrame(
+        {
+            "funding_round_id": ["a", "b", "c", "d"],
+            "announced_on": ["2001-02-01", "2002-10-01", "2002-12-05", "2004-04-01"],
+            "raised_amount_usd": [10, 20, 30, 50],
+            "raised_amount_gbp": [12, 24, 36, 58],
+        }
+    )
+    aggregated_df = cb_investments_per_period(mock_df, "Y", 2001, 2004)
+    aggregated_data = pd.DataFrame(
+        {
+            "time_period": ["2001-01-01", "2002-01-01", "2003-01-01", "2004-01-01"],
+            "no_of_rounds": [1.0, 2.0, 0.0, 1.0],
+            "raised_amount_usd_total": [10.0, 50.0, 0.0, 50.0],
+            "raised_amount_gbp_total": [12.0, 60.0, 0.0, 58.0],
+        }
+    ).astype({"time_period": "datetime64[ns]"})
+    assert_frame_equal(aggregated_df, aggregated_data)
 
 
 def test_cb_get_all_timeseries():
-    mock_organisation_data = {
-        "id": ["a", "b", "c", "d"],
-        "founded_on": ["2001-02-01", "2002-10-01", "2002-12-05", "2004-04-01"],
-    }
-    mock_deal_data = {
-        "funding_round_id": ["a", "b", "c", "d"],
-        "announced_on": ["2001-02-01", "2002-10-01", "2002-12-05", "2004-04-01"],
-        "raised_amount_usd": [10, 20, 30, 50],
-        "raised_amount_gbp": [12, 24, 36, 58],
-    }
-    output = cb_get_all_timeseries(
-        pd.DataFrame(mock_organisation_data), pd.DataFrame(mock_deal_data)
+    mock_organisation_data = pd.DataFrame(
+        {
+            "id": ["a", "b", "c", "d"],
+            "founded_on": ["2001-02-01", "2002-10-01", "2002-12-05", "2004-04-01"],
+        }
     )
-    output_data = {
-        "year": [2001, 2002, 2003, 2004],
-        "no_of_rounds": [1, 2, 0, 1],
-        "raised_amount_usd_total": [10, 50, 0, 50],
-        "raised_amount_gbp_total": [12, 60, 0, 58],
-        "no_of_orgs_founded": [1, 2, 0, 1],
-    }
-    assert_frame_equal(output, pd.DataFrame(output_data))
+    mock_deal_data = pd.DataFrame(
+        {
+            "funding_round_id": ["a", "b", "c", "d"],
+            "announced_on": ["2001-02-01", "2002-10-01", "2002-12-05", "2004-04-01"],
+            "raised_amount_usd": [10, 20, 30, 50],
+            "raised_amount_gbp": [12, 24, 36, 58],
+        }
+    )
+    output = cb_get_all_timeseries(
+        mock_organisation_data, mock_deal_data, "year", 2001, 2004
+    )
+    output_data = pd.DataFrame(
+        {
+            "time_period": ["2001-01-01", "2002-01-01", "2003-01-01", "2004-01-01"],
+            "no_of_rounds": [1.0, 2.0, 0.0, 1.0],
+            "raised_amount_usd_total": [10.0, 50.0, 0.0, 50.0],
+            "raised_amount_gbp_total": [12.0, 60.0, 0.0, 58.0],
+            "no_of_orgs_founded": [1.0, 2.0, 0.0, 1.0],
+        }
+    ).astype({"time_period": "datetime64[ns]"})
+    assert_frame_equal(output, output_data)
 
 
 def test_moving_average():

--- a/innovation_sweet_spots/tests/test_analysis_utils.py
+++ b/innovation_sweet_spots/tests/test_analysis_utils.py
@@ -86,6 +86,76 @@ def test_gtr_funding_per_period():
     assert_frame_equal(aggregated_df, aggregated_data)
 
 
+def test_gtr_funding_median_per_period():
+    # Test yearly median
+    mock_input_data = {
+        "start": [
+            "2001-02-01",
+            "2001-10-01",
+            "2001-10-10",
+            "2002-12-05",
+            "2002-12-12",
+            "2002-04-01",
+        ],
+        "project_id": ["a", "b", "c", "d", "e", "f"],
+        "amount": [1000, 2000, 3000, 10000, 5000, 12000],
+    }
+    mock_df = pd.DataFrame(mock_input_data)
+    aggregated_df = gtr_funding_median_per_period(
+        mock_df, period="year", min_year=2001, max_year=2002
+    )
+    aggregated_data = pd.DataFrame(
+        {
+            "time_period": ["2001-01-01", "2002-01-01"],
+            "amount_median": [2.0, 10.0],
+        }
+    ).astype({"time_period": "datetime64[ns]"})
+    assert_frame_equal(aggregated_df, aggregated_data)
+
+    # Test quarterly median
+    mock_input_data = {
+        "start": [
+            "2005-02-01",
+            "2005-10-01",
+            "2005-10-10",
+            "2006-04-01",
+            "2006-12-05",
+            "2006-12-12",
+        ],
+        "project_id": ["a", "b", "c", "d", "e", "f"],
+        "amount": [1000, 2000, 3000, 10000, 5000, 12000],
+    }
+    mock_df = pd.DataFrame(mock_input_data)
+    aggregated_df = gtr_funding_median_per_period(
+        mock_df, period="quarter", min_year=2005, max_year=2005
+    )
+    aggregated_data = pd.DataFrame(
+        {
+            "time_period": [
+                "2005-01-01",
+                "2005-04-01",
+                "2005-07-01",
+                "2005-10-01",
+                "2006-01-01",
+                "2006-04-01",
+                "2006-07-01",
+                "2006-10-01",
+            ],
+            "amount_median": [
+                1.0,
+                0.0,
+                0.0,
+                2.5,
+                0.0,
+                10.0,
+                0.0,
+                8.5,
+            ],
+        }
+    ).astype({"time_period": "datetime64[ns]"})
+    assert_frame_equal(aggregated_df, aggregated_data)
+
+
 def test_gtr_get_all_timeseries_period():
     mock_df = pd.DataFrame(
         {


### PR DESCRIPTION
Closes #99.

This PR:
* Adds function `gtr_funding_per_period` to `innovation_sweet_spots/analysis/analysis_utils.py` which replaces `gtr_funding_per_year`. This allows GtR timeseries data to be grouped by time periods other than years. Also, this can be used to achieve a more representative split as described in issue 95 by first splitting the data using `GtrWrangler.split_funding_data` into monthly data and then grouping using `gtr_funding_per_period` function by years or quarters. Closes #95.
* Adds function `gtr_get_all_timeseries_period` to `innovation_sweet_spots/analysis/analysis_utils.py` which replaces `gtr_get_all_timeseries` that can be used with monthly, quarterly and yearly data.
* Updates `innovation_sweet_spots/pipeline/pilot/timeseries_gtr.py` to use new function `gtr_get_all_timeseries_period`
* Updates functions relating to generating Crunchbase time series data in `innovation_sweet_spots/analysis/analysis_utils.py` to allow data to be grouped into months, quarters and years.
* Updates `innovation_sweet_spots/pipeline/pilot/timeseries_cb.py` to use updated functions and filter dates at the start of the processing.
* Updates `innovation_sweet_spots/tests/test_analysis_utils.py` to work with new functions
* Adds typer to `timeseries_cb.py` and `timeseries_gtr.py`  to give command line options

