### PR TITLE
[141] Updating Crunchbase dataset (March 2021 snapshot)

### DIFF
--- a/innovation_sweet_spots/analysis/wrangling_utils.py
+++ b/innovation_sweet_spots/analysis/wrangling_utils.py
@@ -417,7 +417,15 @@ class CrunchbaseWrangler:
     investment rounds (deals) and investors participating in the deals
     """
 
-    def __init__(self):
+    def __init__(self, cb_data_path: str = None):
+        """
+        Sets up the CrunchbaseWrangler class
+
+        Args:
+            cb_data_path: Optional argument to specify the location of the
+                Crunchbase data, if it is different from the default location;
+                NB: Note that this changes a global variable.
+        """
         # Tables from the database
         self._cb_organisations = None
         self._cb_funding_rounds = None
@@ -432,6 +440,9 @@ class CrunchbaseWrangler:
         self._industry_groups = None
         self._industry_to_group = None
         self._group_to_industries = None
+        # Set data path (optional)
+        if cb_data_path is not None:
+            cb.CB_PATH = cb_data_path
 
     @property
     def cb_organisations(self):

--- a/innovation_sweet_spots/getters/crunchbase.py
+++ b/innovation_sweet_spots/getters/crunchbase.py
@@ -8,6 +8,28 @@ import pandas as pd
 from innovation_sweet_spots.getters.path_utils import CB_PATH
 
 
+def restore_column_names(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Renames columns to ensure that utils functions written to process
+    the older Crunchbase data snapshots also work with the newer
+    snapshots (where columns storing unique identifiers have been renamed).
+    """
+    return df.rename(
+        columns={
+            "uuid": "id",
+            "org_uuid": "org_id",
+            "lead_investor_uuids": "lead_investor_ids",
+            "funding_round_uuid": "funding_round_id",
+            "investor_uuid": "investor_id",
+            "featured_job_organization_uuid": "featured_job_organization_id",
+            "person_uuid": "person_id",
+            "institution_uuid": "institution_id",
+            "acquiree_uuid": "acquiree_id",
+            "acquirer_uuid": "acquirer_id",
+        }
+    )
+
+
 def get_crunchbase_category_groups() -> pd.DataFrame:
     """Table with company categories (also called 'industries') and broader 'category groups'"""
     return pd.read_csv(CB_PATH / "crunchbase_category_groups.csv")
@@ -30,34 +52,40 @@ def get_crunchbase_organizations_categories() -> pd.DataFrame:
 
 def get_crunchbase_funding_rounds() -> pd.DataFrame:
     """Table with investment rounds (NB: one round can have several investments)"""
-    return pd.read_csv(CB_PATH / "crunchbase_funding_rounds.csv")
+    return pd.read_csv(CB_PATH / "crunchbase_funding_rounds.csv").pipe(
+        restore_column_names
+    )
 
 
 def get_crunchbase_investments() -> pd.DataFrame:
     """Table with investments"""
-    return pd.read_csv(CB_PATH / "crunchbase_investments.csv")
+    return pd.read_csv(CB_PATH / "crunchbase_investments.csv").pipe(
+        restore_column_names
+    )
 
 
 def get_crunchbase_investors() -> pd.DataFrame:
     """Table with investors"""
-    return pd.read_csv(CB_PATH / "crunchbase_investors.csv")
+    return pd.read_csv(CB_PATH / "crunchbase_investors.csv").pipe(restore_column_names)
 
 
 def get_crunchbase_people() -> pd.DataFrame:
     """Table with people"""
-    return pd.read_csv(CB_PATH / "crunchbase_people.csv")
+    return pd.read_csv(CB_PATH / "crunchbase_people.csv").pipe(restore_column_names)
 
 
 def get_crunchbase_degrees() -> pd.DataFrame:
     """Table with university degrees"""
-    return pd.read_csv(CB_PATH / "crunchbase_degrees.csv")
+    return pd.read_csv(CB_PATH / "crunchbase_degrees.csv").pipe(restore_column_names)
 
 
 def get_crunchbase_ipos() -> pd.DataFrame:
     """Table with crunchbase ipos"""
-    return pd.read_csv(CB_PATH / "crunchbase_ipos.csv")
+    return pd.read_csv(CB_PATH / "crunchbase_ipos.csv").pipe(restore_column_names)
 
 
 def get_crunchbase_acquisitions() -> pd.DataFrame:
     """Table with crunchbase acquisitions"""
-    return pd.read_csv(CB_PATH / "crunchbase_acquisitions.csv")
+    return pd.read_csv(CB_PATH / "crunchbase_acquisitions.csv").pipe(
+        restore_column_names
+    )

--- a/innovation_sweet_spots/tests/data_tests/test_crunchbase.py
+++ b/innovation_sweet_spots/tests/data_tests/test_crunchbase.py
@@ -1,9 +1,11 @@
 """
 A simple test suite reports some basic information about Crunchbase data
 
-Usage (from the terminal):
-
+Usage examples (running from the terminal):
+1) To check the default dataset
 python innovation_sweet_spots/tests/data_tests/test_crunchbase.py
+2) To check a different data snapshot in a differently named folder (NB: should be still in inputs/data)
+python innovation_sweet_spots/tests/data_tests/test_crunchbase.py --data-folder-name cb_2021
 """
 
 from innovation_sweet_spots.analysis.wrangling_utils import CrunchbaseWrangler

--- a/innovation_sweet_spots/tests/data_tests/test_crunchbase.py
+++ b/innovation_sweet_spots/tests/data_tests/test_crunchbase.py
@@ -1,0 +1,85 @@
+"""
+A simple test suite reports some basic information about Crunchbase data
+
+"""
+
+from innovation_sweet_spots.analysis.wrangling_utils import CrunchbaseWrangler
+from innovation_sweet_spots import logging, PROJECT_DIR
+import typer
+
+
+def define_data_path(folder_name: str = None):
+    """
+    Defines the path to Crunchbase data, given the folder name.
+    NB: The folder should be located in 'inputs/data'.
+    """
+    if folder_name is None:
+        return None
+    else:
+        return PROJECT_DIR / f"inputs/data/{folder_name}"
+
+
+def log_total_number(CB: CrunchbaseWrangler):
+    """Total number of organisations"""
+    n = len(CB.cb_organisations)
+    logging.info(f"There are {n} organisations in the table 'crunchbase_organisations'")
+
+
+def log_uk_number(CB: CrunchbaseWrangler):
+    """Organisations in the UK"""
+    n_uk = len(CB.cb_organisations.query('country == "United Kingdom"'))
+    logging.info(f"There are {n_uk} UK organisations")
+
+
+def log_top_countries(CB: CrunchbaseWrangler):
+    """Top countries by the number of organisations"""
+    top_countries = (
+        CB.cb_organisations.groupby("country")
+        .agg(counts=("id", "count"))
+        .sort_values("counts", ascending=False)
+        .head(10)
+    )
+    logging.info(f"Top countries by the number of organisations:\n{top_countries}")
+
+
+def log_number_of_industries(CB: CrunchbaseWrangler):
+    """Number of unique categories/industries and industry groups"""
+    n_industries = len(CB.industries)
+    n_groups = len(CB.industry_groups)
+    logging.info(
+        f"Organisations are categorised across {n_industries} industries, which in turn are grouped into {n_groups} broader categories"
+    )
+
+
+def log_number_funding_rounds(CB: CrunchbaseWrangler):
+    """Number of funding rounds"""
+    n_rounds = len(CB.cb_funding_rounds)
+    logging.info(
+        f"There are {n_rounds} funding rounds in the table 'crunchbase_funding_rounds'"
+    )
+
+
+def log_number_people(CB: CrunchbaseWrangler):
+    """Number of funding rounds"""
+    n_people = len(CB.cb_people)
+    logging.info(
+        f"There is data about {n_people} people in the table 'crunchbase_people'"
+    )
+
+
+def print_all_logs(CB: CrunchbaseWrangler):
+    """Performs all checks and prints logs"""
+    log_total_number(CB)
+    log_uk_number(CB)
+    log_top_countries(CB)
+    log_number_of_industries(CB)
+    log_number_funding_rounds(CB)
+    log_number_people(CB)
+
+
+def produce_logs(data_folder_name: str = None):
+    print_all_logs(CrunchbaseWrangler(define_data_path(data_folder_name)))
+
+
+if __name__ == "__main__":
+    typer.run(produce_logs)

--- a/innovation_sweet_spots/tests/data_tests/test_crunchbase.py
+++ b/innovation_sweet_spots/tests/data_tests/test_crunchbase.py
@@ -1,6 +1,9 @@
 """
 A simple test suite reports some basic information about Crunchbase data
 
+Usage (from the terminal):
+
+python innovation_sweet_spots/tests/data_tests/test_crunchbase.py
 """
 
 from innovation_sweet_spots.analysis.wrangling_utils import CrunchbaseWrangler


### PR DESCRIPTION
This PR marks an update to the Crunchbase dataset with the most recent snapshot (March 2022) and closes #141 

The updated dataset has replaced the previous one in the s3 folder `inputs/data/cb` (previous snapshot was from August 2021).

The previous snapshot is now in the folder `cb_2021`. By default, `CrunchbaseWrangler` loads the data from `cb`, but I have added an input argument for initialising the class, that allows to optionally specify another folder (eg, `"cb_2021"`).

This PR also adds a simple test script that allows to quickly check some basic information about the dataset. The test script can be run from the terminal as follows:
```shell
python innovation_sweet_spots/tests/data_tests/test_crunchbase.py
```

The expected output for the latest snapshot is:
```
2022-04-07 18:29:37,540 - root - INFO - There are 1900438 organisations in the table 'crunchbase_organisations'
2022-04-07 18:29:37,825 - root - INFO - There are 131011 UK organisations
2022-04-07 18:29:38,052 - root - INFO - Top countries by the number of organisations:
                counts
country               
United States   742992
United Kingdom  131011
India            69492
Germany          68354
Canada           61335
Japan            47672
France           45139
Netherlands      44876
China            44484
Australia        40124
2022-04-07 18:29:38,063 - root - INFO - Organisations are categorised across 744 industries, which in turn are grouped into 47 broader categories
2022-04-07 18:29:41,677 - root - INFO - There are 473371 funding rounds in the table 'crunchbase_funding_rounds'
2022-04-07 18:29:53,387 - root - INFO - There is data about 1415769 people in the table 'crunchbase_people'
```

Alternatively, you can specify another folder:
```shell
python innovation_sweet_spots/tests/data_tests/test_crunchbase.py --data-folder-name cb_2021
```

The expected output using the previous snapshot is:
```
2022-04-07 18:31:27,700 - root - INFO - There are 1525107 organisations in the table 'crunchbase_organisations'
2022-04-07 18:31:27,986 - root - INFO - There are 97682 UK organisations
2022-04-07 18:31:28,189 - root - INFO - Top countries by the number of organisations:
                counts
country               
United States   556485
United Kingdom   97682
India            56648
Canada           49487
Germany          48886
China            41709
Japan            39048
Netherlands      38524
France           33033
Australia        25370
2022-04-07 18:31:28,205 - root - INFO - Organisations are categorised across 744 industries, which in turn are grouped into 46 broader categories
2022-04-07 18:31:31,750 - root - INFO - There are 428866 funding rounds in the table 'crunchbase_funding_rounds'
2022-04-07 18:31:43,664 - root - INFO - There is data about 1223555 people in the table 'crunchbase_people'
```

Don't want to spend too much time optimising this particular test script, but I'm very interested if you have any opinions about how good "data tests" (as opposed to function unit tests) should and could generally look like!

---

Checklist:

- [x] I have refactored my code out from `notebooks/`
- [x] I have checked the code runs
- [x] I have tested the code
- [x] I have run `pre-commit` and addressed any issues not automatically fixed
- [x] I have merged any new changes from `dev`
- [x] I have documented the code
  - [x] Major functions have docstrings
  - [ ] Appropriate information has been added to `README`s
- [x] I have explained the feature in this PR or (better) in `output/reports/`
- [x] I have requested a code review
