### PR TITLE
[144] Add BEIS indicators to investments prediction dataset creation

### DIFF
--- a/innovation_sweet_spots/getters/beis_indicators.py
+++ b/innovation_sweet_spots/getters/beis_indicators.py
@@ -7,7 +7,6 @@ https://access-research-development-spatial-data.beis.gov.uk/indicators
 from innovation_sweet_spots.getters.path_utils import INPUTS_PATH
 from innovation_sweet_spots.utils.io import unzip_files
 import pandas as pd
-import os
 import urllib
 
 # Data version to use

--- a/innovation_sweet_spots/getters/crunchbase.py
+++ b/innovation_sweet_spots/getters/crunchbase.py
@@ -5,7 +5,11 @@ Module for easy access to downloaded CB data
 
 """
 import pandas as pd
-from innovation_sweet_spots.getters.path_utils import CB_PATH, CB_GTR_LINK_PATH
+from innovation_sweet_spots.getters.path_utils import (
+    CB_PATH,
+    CB_GTR_LINK_PATH,
+    PILOT_OUTPUTS,
+)
 
 
 def restore_column_names(df: pd.DataFrame) -> pd.DataFrame:
@@ -95,3 +99,9 @@ def get_crunchbase_gtr_lookup() -> pd.DataFrame:
     """Table with UK Crunchbase organisation ids with fuzzy
     matched Gateway to Research organisation ids"""
     return pd.read_csv(CB_GTR_LINK_PATH / "cb_gtr_id_lookup.csv", index_col=0)
+
+
+def get_pilot_crunchbase_companies() -> pd.DataFrame:
+    """Table with companies identified as
+    emerging green technology companies in the ISS pilot"""
+    return pd.read_csv(PILOT_OUTPUTS / "ISS_pilot_Crunchbase_companies.csv")

--- a/innovation_sweet_spots/getters/crunchbase_beis.py
+++ b/innovation_sweet_spots/getters/crunchbase_beis.py
@@ -1,0 +1,20 @@
+from innovation_sweet_spots.getters.path_utils import PILOT_OUTPUTS
+import pandas as pd
+from innovation_sweet_spots.pipeline.pilot.investment_predictions.create_dataset.create_beis_indicators import (
+    create_beis_indicators,
+)
+
+
+def get_crunchbase_beis(year) -> pd.DataFrame:
+    """Load table with crunchbase org_id, location_id and related beis indicators
+    If the file exists locally, will load, otherwise will create
+
+    Args:
+        year: Attempt to load BEIS indicators for up to the specified year
+            e.g if year is 2018, it will load values for 2017"""
+    crunchbase_beis_fp = (
+        PILOT_OUTPUTS / f"investment_predictions/company_beis_indicators_{year}.csv"
+    )
+    if not crunchbase_beis_fp.exists():
+        create_beis_indicators(year)
+    return pd.read_csv(crunchbase_beis_fp)

--- a/innovation_sweet_spots/pipeline/pilot/investment_predictions/create_dataset/create_dataset.py
+++ b/innovation_sweet_spots/pipeline/pilot/investment_predictions/create_dataset/create_dataset.py
@@ -9,7 +9,6 @@ On an M1 macbook it takes ~8 mins 30 secs to run on the full dataset and ~1 mins
 """
 import typer
 from innovation_sweet_spots import PROJECT_DIR
-from innovation_sweet_spots.getters import crunchbase
 from innovation_sweet_spots.getters.crunchbase import (
     get_crunchbase_funding_rounds,
     get_crunchbase_ipos,
@@ -30,9 +29,6 @@ from innovation_sweet_spots.analysis.wrangling_utils import (
     CrunchbaseWrangler,
     GtrWrangler,
 )
-
-# Adjust the Crunchbase data snapshot path (ideally, should adapt the code to accommodate the newest snapshot)
-crunchbase.CB_PATH = crunchbase.CB_PATH.parents[0] / "cb_2021"
 
 KEEP_COLS = [
     "id",

--- a/innovation_sweet_spots/pipeline/pilot/investment_predictions/create_dataset/create_dataset.py
+++ b/innovation_sweet_spots/pipeline/pilot/investment_predictions/create_dataset/create_dataset.py
@@ -371,6 +371,8 @@ def create_dataset(
         .pipe(utils.add_beis_indicators, cb_beis_processed)
         # Add dummy cols for green tech categories
         .pipe(utils.add_green_tech_cats, green_pilot_lookup=utils.green_pilot_lookup())
+        # Drop rows without a location_id
+        .dropna(subset=["location_id"])
         # Drop columns
         .pipe(
             utils.drop_multi_cols,

--- a/innovation_sweet_spots/pipeline/pilot/investment_predictions/create_dataset/create_dataset.py
+++ b/innovation_sweet_spots/pipeline/pilot/investment_predictions/create_dataset/create_dataset.py
@@ -392,6 +392,8 @@ def create_dataset(
         .pipe(utils.add_n_months_before_first_grant)
         # Add cols for BEIS indicators
         .pipe(utils.add_beis_indicators, cb_beis_processed)
+        # Add dummy cols for green tech categories
+        .pipe(utils.add_green_tech_cats, green_pilot_lookup=utils.green_pilot_lookup())
         # Drop columns
         .pipe(
             utils.drop_multi_cols,

--- a/innovation_sweet_spots/pipeline/pilot/investment_predictions/create_dataset/create_dataset.py
+++ b/innovation_sweet_spots/pipeline/pilot/investment_predictions/create_dataset/create_dataset.py
@@ -243,19 +243,7 @@ def create_dataset(
         cb_orgs = cb_orgs.pipe(utils.add_group_dummies, industry_to_group_map)
 
     # Add founder info to people info
-    cb_people = (
-        cb_people.pipe(utils.add_clean_job_title)
-        .pipe(utils.add_is_founder)
-        .pipe(utils.add_is_gender, gender="male")
-        .dropna(subset=["featured_job_organization_id"])
-        .rename(
-            columns={
-                "id": "person_id",
-                "featured_job_organization_id": "org_id",
-            }
-        )
-        .reset_index(drop=True)
-    )
+    cb_people = utils.add_founder_features_to_people(cb_people)
 
     # Create dataframe for person id and degree count
     person_degree_count = utils.person_id_degree_count(cb_degrees)
@@ -266,14 +254,7 @@ def create_dataset(
     )
 
     # Create dataframe for org_id with grouped founders data
-    org_id_founders = (
-        cb_founders.groupby("org_id").agg(
-            founder_count=("is_founder", "sum"),
-            male_founder_percentage=("is_male_founder", "mean"),
-            founder_max_degrees=("degree_count", "max"),
-            founder_mean_degrees=("degree_count", "mean"),
-        )
-    ).reset_index()
+    org_id_founders = utils.groupby_founders_features(cb_founders)
 
     dataset = (
         # Add flag for founded on and filter out companies with 0 flag

--- a/innovation_sweet_spots/pipeline/pilot/investment_predictions/create_dataset/create_dataset.py
+++ b/innovation_sweet_spots/pipeline/pilot/investment_predictions/create_dataset/create_dataset.py
@@ -5,7 +5,7 @@ used for predicting future investment sucess for companies.
 Run the following command in the terminal to see the options for creating the dataset:
 python innovation_sweet_spots/pipeline/pilot/investment_predictions/create_dataset/create_dataset.py --help
 
-On an M1 macbook it takes ~8 mins 30 secs to run on the full dataset and ~1 mins 30 secs to run in test mode.
+On an M1 macbook it takes ~14 mins to run on the full dataset and ~1 mins 30 secs to run in test mode.
 """
 import typer
 from innovation_sweet_spots import PROJECT_DIR
@@ -125,12 +125,12 @@ def create_dataset(
     cb_wrangler = CrunchbaseWrangler()
 
     # Load datasets
-    nrows = 5000 if test else None
+    nrows = 20_000 if test else None
     cb_orgs = (
         get_crunchbase_orgs(nrows)
         .query("country_code == 'GBR'")
         .assign(founded_on=lambda x: pd.to_datetime(x.founded_on, errors="coerce"))
-        .reset_index()
+        .reset_index(drop=True)
     )
     cb_acquisitions = get_crunchbase_acquisitions()
     cb_ipos = get_crunchbase_ipos()

--- a/innovation_sweet_spots/pipeline/pilot/investment_predictions/create_dataset/create_dataset.py
+++ b/innovation_sweet_spots/pipeline/pilot/investment_predictions/create_dataset/create_dataset.py
@@ -128,14 +128,13 @@ def create_dataset(
     cb_wrangler = CrunchbaseWrangler()
 
     # Load datasets
+    nrows = 5000 if test else None
     cb_orgs = (
-        get_crunchbase_orgs()
+        get_crunchbase_orgs(nrows)
         .query("country_code == 'GBR'")
         .assign(founded_on=lambda x: pd.to_datetime(x.founded_on, errors="coerce"))
         .reset_index()
     )
-    if test:
-        cb_orgs = cb_orgs.head(2000)
     cb_acquisitions = get_crunchbase_acquisitions()
     cb_ipos = get_crunchbase_ipos()
     cb_funding_rounds_grants = get_crunchbase_funding_rounds().assign(

--- a/innovation_sweet_spots/pipeline/pilot/investment_predictions/create_dataset/create_dataset.py
+++ b/innovation_sweet_spots/pipeline/pilot/investment_predictions/create_dataset/create_dataset.py
@@ -5,7 +5,7 @@ used for predicting future investment sucess for companies.
 Run the following command in the terminal to see the options for creating the dataset:
 python innovation_sweet_spots/pipeline/pilot/investment_predictions/create_dataset/create_dataset.py --help
 
-On an M1 macbook it takes ~8 mins 30 secs to run on the full dataset and ~2 mins 30 secs to run in test mode.
+On an M1 macbook it takes ~8 mins 30 secs to run on the full dataset and ~1 mins 30 secs to run in test mode.
 """
 import typer
 from innovation_sweet_spots import PROJECT_DIR
@@ -21,6 +21,7 @@ from innovation_sweet_spots.getters.crunchbase import (
     get_crunchbase_gtr_lookup,
 )
 from innovation_sweet_spots.getters.gtr import get_link_table
+from innovation_sweet_spots.getters.crunchbase_beis import get_crunchbase_beis
 from innovation_sweet_spots.pipeline.pilot.investment_predictions.create_dataset import (
     utils,
 )
@@ -144,6 +145,8 @@ def create_dataset(
     cb_investments = get_crunchbase_investments()
     cb_people = get_crunchbase_people()
     cb_degrees = get_crunchbase_degrees()
+    cb_beis = get_crunchbase_beis(window_end_date.year)
+    cb_beis_processed = utils.process_cb_beis(cb_beis)
 
     # Convert funding amounts to GBP
     cb_funding_rounds_grants_gbp = cb_wrangler.convert_deal_currency_to_gbp(
@@ -387,6 +390,8 @@ def create_dataset(
         .pipe(utils.add_n_months_since_last_grant, window_end_date)
         # Add col for number of before first grant
         .pipe(utils.add_n_months_before_first_grant)
+        # Add cols for BEIS indicators
+        .pipe(utils.add_beis_indicators, cb_beis_processed)
         # Drop columns
         .pipe(
             utils.drop_multi_cols,

--- a/innovation_sweet_spots/pipeline/pilot/investment_predictions/create_dataset/create_dataset.py
+++ b/innovation_sweet_spots/pipeline/pilot/investment_predictions/create_dataset/create_dataset.py
@@ -101,8 +101,8 @@ UKRI_GRANT_PROVIDERS_TO_FILTER = (
 
 
 def create_dataset(
-    window_start_date: str = "01/01/2010",
-    window_end_date: str = "01/01/2018",
+    window_start_date: str = "01/01/2011",
+    window_end_date: str = "01/01/2019",
     industries_or_groups: str = "groups",
     test: bool = False,
 ):
@@ -399,7 +399,7 @@ def create_dataset(
             utils.drop_multi_cols,
             cols_to_drop_str_containing=DROP_MULTI_COLS,
         )
-        .drop(columns=DROP_COLS)
+        .drop(columns=DROP_COLS, errors="ignore")
         .reset_index(drop=True)
     )
     dataset.to_csv(

--- a/innovation_sweet_spots/pipeline/pilot/investment_predictions/create_dataset/create_dataset.py
+++ b/innovation_sweet_spots/pipeline/pilot/investment_predictions/create_dataset/create_dataset.py
@@ -381,12 +381,13 @@ def create_dataset(
         .drop(columns=DROP_COLS, errors="ignore")
         .reset_index(drop=True)
     )
+    test_indicator = "_test" if test else ""
     dataset.to_csv(
         PROJECT_DIR
         / "outputs/finals/pilot_outputs"
         / "investment_predictions/company_data_window_"
         f"{str(window_start_date).split(' ')[0]}-{str(window_end_date).split(' ')[0]}"
-        ".csv"
+        f"{test_indicator}.csv"
     )
 
 

--- a/innovation_sweet_spots/pipeline/pilot/investment_predictions/create_dataset/utils.py
+++ b/innovation_sweet_spots/pipeline/pilot/investment_predictions/create_dataset/utils.py
@@ -923,11 +923,19 @@ def gtr_projects_with_lead_orgs(
 
 def process_cb_beis(cb_beis: pd.DataFrame) -> pd.DataFrame:
     """Drop columns name, id, nuts2_2010, nuts2_2013, nuts2_2016
-    and duplicate rows from cb_beis file
+    and duplicate rows from cb_beis file. Add prefix 'beis_' to columns
     """
-    return cb_beis.drop(
-        columns=["name", "id", "nuts2_2010", "nuts2_2013", "nuts2_2016"]
-    ).drop_duplicates()
+    return (
+        cb_beis.drop(columns=["name", "id", "nuts2_2010", "nuts2_2013", "nuts2_2016"])
+        .drop_duplicates()
+        .rename(
+            columns={
+                col: f"beis_{col}"
+                for col in cb_beis.columns
+                if col not in ["id", "name", "location_id"]
+            }
+        )
+    )
 
 
 def add_beis_indicators(

--- a/innovation_sweet_spots/pipeline/pilot/investment_predictions/create_dataset/utils.py
+++ b/innovation_sweet_spots/pipeline/pilot/investment_predictions/create_dataset/utils.py
@@ -58,6 +58,7 @@ def add_industry_dummies(cb_orgs: pd.DataFrame) -> pd.DataFrame:
         .sum(level=0)
         .add_prefix("ind_")
     )
+    industry_dummies.columns = industry_dummies.columns.str.replace(" ", "_")
     return cb_orgs.merge(industry_dummies, left_index=True, right_index=True)
 
 
@@ -79,6 +80,7 @@ def add_group_dummies(
     group_dummies = (
         pd.get_dummies(cb_orgs["groups"].explode()).sum(level=0).add_prefix("group_")
     )
+    group_dummies.columns = group_dummies.columns.str.replace(" ", "_")
     return cb_orgs.merge(group_dummies, left_index=True, right_index=True)
 
 

--- a/innovation_sweet_spots/pipeline/pilot/investment_predictions/create_dataset/utils.py
+++ b/innovation_sweet_spots/pipeline/pilot/investment_predictions/create_dataset/utils.py
@@ -1004,3 +1004,32 @@ def add_green_tech_cats(
         left_on="id",
         right_on="id",
     ).fillna(fill_na_dict)
+
+
+def add_founder_features_to_people(cb_people: pd.DataFrame) -> pd.DataFrame:
+    """Add founder related features to crunchbase people data"""
+    return (
+        cb_people.pipe(add_clean_job_title)
+        .pipe(add_is_founder)
+        .pipe(add_is_gender, gender="male")
+        .dropna(subset=["featured_job_organization_id"])
+        .rename(
+            columns={
+                "id": "person_id",
+                "featured_job_organization_id": "org_id",
+            }
+        )
+        .reset_index(drop=True)
+    )
+
+
+def groupby_founders_features(cb_founders: pd.DataFrame) -> pd.DataFrame:
+    """Groupbys founders features relating to each org_id"""
+    return (
+        cb_founders.groupby("org_id").agg(
+            founder_count=("is_founder", "sum"),
+            male_founder_percentage=("is_male_founder", "mean"),
+            founder_max_degrees=("degree_count", "max"),
+            founder_mean_degrees=("degree_count", "mean"),
+        )
+    ).reset_index()

--- a/innovation_sweet_spots/pipeline/pilot/investment_predictions/create_dataset/utils.py
+++ b/innovation_sweet_spots/pipeline/pilot/investment_predictions/create_dataset/utils.py
@@ -53,7 +53,11 @@ def ind_to_group(industries: list, industry_to_group_map: dict) -> set:
 
 def add_industry_dummies(cb_orgs: pd.DataFrame) -> pd.DataFrame:
     """Adds dummy columns for industries"""
-    industry_dummies = pd.get_dummies(cb_orgs["industry_clean"].explode()).sum(level=0)
+    industry_dummies = (
+        pd.get_dummies(cb_orgs["industry_clean"].explode())
+        .sum(level=0)
+        .add_prefix("ind_")
+    )
     return cb_orgs.merge(industry_dummies, left_index=True, right_index=True)
 
 
@@ -72,7 +76,9 @@ def add_group_dummies(
     cb_orgs["groups"] = cb_orgs["industry_clean"].apply(
         ind_to_group, args=(industry_to_group_map,)
     )
-    group_dummies = pd.get_dummies(cb_orgs["groups"].explode()).sum(level=0)
+    group_dummies = (
+        pd.get_dummies(cb_orgs["groups"].explode()).sum(level=0).add_prefix("group_")
+    )
     return cb_orgs.merge(group_dummies, left_index=True, right_index=True)
 
 

--- a/innovation_sweet_spots/pipeline/pilot/investment_predictions/create_dataset/utils.py
+++ b/innovation_sweet_spots/pipeline/pilot/investment_predictions/create_dataset/utils.py
@@ -931,3 +931,32 @@ def gtr_projects_with_lead_orgs(
             how="left",
         )[["project_id", "fund_start", "amount", "gtr_org_id"]]
     )
+
+
+def process_cb_beis(cb_beis):
+    """Drop columns name, id, nuts2_2010, nuts2_2013, nuts2_2016
+    and duplicate rows from cb_beis file
+    """
+    return cb_beis.drop(
+        columns=["name", "id", "nuts2_2010", "nuts2_2013", "nuts2_2016"]
+    ).drop_duplicates()
+
+
+def add_beis_indicators(cb_data, cb_beis_processed):
+    """Add columns for the BEIS indicators to the dataset
+
+    Args:
+        cb_data: Dataframe to add number BEIS indicators too,
+            must contain column for 'location_id'
+        cb_beis_processed: Dataframe containing 'location_id' and BEIS
+            indicators
+
+    Returns:
+        cb_data with BEIS indicators added
+    """
+    return cb_data.merge(
+        right=cb_beis_processed,
+        how="left",
+        left_on="location_id",
+        right_on="location_id",
+    )

--- a/innovation_sweet_spots/pipeline/pilot/investment_predictions/create_dataset/utils.py
+++ b/innovation_sweet_spots/pipeline/pilot/investment_predictions/create_dataset/utils.py
@@ -817,7 +817,7 @@ def add_gtr_project_to_cb_gtr_lookup(
     )
 
 
-def standardise_gtr_grants(cb_gtr_lookup_projects):
+def standardise_gtr_grants(cb_gtr_lookup_projects: pd.DataFrame) -> pd.DataFrame:
     """Standardise gtr grants data so that it can be
     combined with crunchbase grants data"""
     return (
@@ -915,7 +915,7 @@ def gtr_projects_with_lead_orgs(
     )
 
 
-def process_cb_beis(cb_beis):
+def process_cb_beis(cb_beis: pd.DataFrame) -> pd.DataFrame:
     """Drop columns name, id, nuts2_2010, nuts2_2013, nuts2_2016
     and duplicate rows from cb_beis file
     """
@@ -924,7 +924,9 @@ def process_cb_beis(cb_beis):
     ).drop_duplicates()
 
 
-def add_beis_indicators(cb_data, cb_beis_processed):
+def add_beis_indicators(
+    cb_data: pd.DataFrame, cb_beis_processed: pd.DataFrame
+) -> pd.DataFrame:
     """Add columns for the BEIS indicators to the dataset
 
     Args:


### PR DESCRIPTION
Closes #144.

This PR:
* Adds a getter for the `company_beis_indicators_year.csv` file (it creates it if it doesn't exist)
* Adds BEIS indicators into the investments prediction dataset
* Adds a getter for `ISS_pilot_Crunchbase_companies.csv`
* Adds green pilot tech categories into the investments prediction dataset
* Adds a prefix to `ind_` or `group_` to industry/group columns
* Updates test mode to load `cb_orgs` quicker
* Updates the default window to 2011-2019
