### PR TITLE
[199] Update creation of investment predictions dataset for all companies worldwide

### DIFF
--- a/innovation_sweet_spots/pipeline/pilot/investment_predictions/create_dataset/create_dataset.py
+++ b/innovation_sweet_spots/pipeline/pilot/investment_predictions/create_dataset/create_dataset.py
@@ -100,6 +100,7 @@ def create_dataset(
     window_start_date: str = "01/01/2011",
     window_end_date: str = "01/01/2019",
     industries_or_groups: str = "groups",
+    uk_only: bool = False,
     test: bool = False,
 ):
     """Loads crunchbase data, processes and saves dataset which can be used
@@ -107,12 +108,14 @@ def create_dataset(
 
     Args:
         window_start_date: Start date for window that simulates the
-            evaluation period for assessing companies. Defaults to "01/01/2014".
+            evaluation period for assessing companies. Defaults to "01/01/2011".
         window_end_date: End date for window that simulates the evaluation period
-            for assessing companies. Defaults to "01/01/2018".
+            for assessing companies. Defaults to "01/01/2019".
         industries_or_groups: 'industries' to have a column to indicate which
             industries the company is in or 'groups' to have a column to indicate
             which wider industry group the company is in.
+        uk_only: If set to True, limits dataset to UK based countries. If set to
+            False, includes all companies worldwide.
         test: If set to True, reduces crunchbase orgs to 5000 records. Set to
             True to quickly check functionality.
     """
@@ -127,11 +130,12 @@ def create_dataset(
     # Load datasets
     nrows = 20_000 if test else None
     cb_orgs = (
-        get_crunchbase_orgs(nrows)
-        .query("country_code == 'GBR'")
+        get_crunchbase_orgs(nrows, filter_invalid_ids=True)
         .assign(founded_on=lambda x: pd.to_datetime(x.founded_on, errors="coerce"))
         .reset_index(drop=True)
     )
+    cb_orgs = cb_orgs.query("country_code == 'GBR'") if uk_only else cb_orgs
+
     cb_acquisitions = get_crunchbase_acquisitions()
     cb_ipos = get_crunchbase_ipos()
     cb_funding_rounds_grants = get_crunchbase_funding_rounds().assign(
@@ -344,8 +348,7 @@ def create_dataset(
         )
         # Add col for number of months since last investment
         .pipe(
-            utils.add_n_months_since_last_investment_in_window,
-            end_date=window_end_date,
+            utils.add_n_months_since_last_investment_in_window, end_date=window_end_date
         )
         # Add col for number of months since founded
         .pipe(utils.add_n_months_since_founded, end_date=window_end_date)
@@ -374,20 +377,18 @@ def create_dataset(
         # Drop rows without a location_id
         .dropna(subset=["location_id"])
         # Drop columns
-        .pipe(
-            utils.drop_multi_cols,
-            cols_to_drop_str_containing=DROP_MULTI_COLS,
-        )
+        .pipe(utils.drop_multi_cols, cols_to_drop_str_containing=DROP_MULTI_COLS)
         .drop(columns=DROP_COLS, errors="ignore")
         .reset_index(drop=True)
     )
     test_indicator = "_test" if test else ""
+    region_indicator = "_ukonly" if uk_only else "_worldwide"
     dataset.to_csv(
         PROJECT_DIR
         / "outputs/finals/pilot_outputs"
         / "investment_predictions/company_data_window_"
         f"{str(window_start_date).split(' ')[0]}-{str(window_end_date).split(' ')[0]}"
-        f"{test_indicator}.csv"
+        f"{test_indicator}{region_indicator}.csv"
     )
 
 

--- a/innovation_sweet_spots/pipeline/pilot/investment_predictions/create_dataset/create_dataset.py
+++ b/innovation_sweet_spots/pipeline/pilot/investment_predictions/create_dataset/create_dataset.py
@@ -5,7 +5,8 @@ used for predicting future investment sucess for companies.
 Run the following command in the terminal to see the options for creating the dataset:
 python innovation_sweet_spots/pipeline/pilot/investment_predictions/create_dataset/create_dataset.py --help
 
-On an M1 macbook it takes ~14 mins to run on the full dataset and ~1 mins 30 secs to run in test mode.
+On an M1 macbook it takes ~14 mins to run on the uk only dataset and ~2 days for the worldwide data.
+There is a test mode which on a small subset of the data that executes in a few mins.
 """
 import typer
 from innovation_sweet_spots import PROJECT_DIR

--- a/innovation_sweet_spots/pipeline/pilot/investment_predictions/create_dataset/create_dataset.py
+++ b/innovation_sweet_spots/pipeline/pilot/investment_predictions/create_dataset/create_dataset.py
@@ -241,9 +241,9 @@ def create_dataset(
     cb_orgs = cb_orgs[KEEP_COLS]
 
     # Add dummy columns for industry information
-    if industries_or_groups is "industries":
+    if industries_or_groups == "industries":
         cb_orgs = cb_orgs.pipe(utils.add_industry_dummies)
-    if industries_or_groups is "groups":
+    if industries_or_groups == "groups":
         cb_orgs = cb_orgs.pipe(utils.add_group_dummies, industry_to_group_map)
 
     # Add founder info to people info


### PR DESCRIPTION
Closes #199.

Closes #198.

This PR:

- Updates crunchbase organisations getter to enable filtering of rows with invalid ids. Any files that currently use this getter will not be effected as the new parameter `filter_invalid_ids` defaults to `False`.
- Updates the investment predictions `create_dataset.py` file to make a dataset with all companies worldwide.

The output files can be found on S3 here: [training dataset (2011-2019)](https://s3.console.aws.amazon.com/s3/object/innovation-sweet-spots-lake?region=eu-west-2&prefix=outputs/finals/pilot_outputs/investment_predictions/company_data_window_2011-01-01-2019-01-01_worldwide.csv) and [future predictions dataset (2014-2022)](https://s3.console.aws.amazon.com/s3/object/innovation-sweet-spots-lake?region=eu-west-2&prefix=outputs/finals/pilot_outputs/investment_predictions/company_data_window_2014-01-04-2022-01-04_worldwide.csv).

---

Checklist:

- [x] I have refactored my code out from `notebooks/`
- [x] I have checked the code runs
- [x] I have tested the code
- [x] I have run `pre-commit` and addressed any issues not automatically fixed
- [x] I have merged any new changes from `dev`
- [x] I have documented the code
  - [x] Major functions have docstrings
  - [x] Appropriate information has been added to `README`s
- [x] I have explained the feature in this PR or (better) in `output/reports/`
- [x] I have requested a code review
